### PR TITLE
docs: record production AMEX preview

### DIFF
--- a/.trellis/spec/perks-reminder/deployment-and-external-effects.md
+++ b/.trellis/spec/perks-reminder/deployment-and-external-effects.md
@@ -26,3 +26,75 @@ Before any Vercel, DNS, cron, email, or production-domain action:
 5. run the narrowest post-change check.
 
 `docs/vercel-domains-and-deploy.md` and `docs/supabase-fallback.md` retain detailed operator procedures. Specs define the safety contract; do not duplicate or casually rewrite provider commands in unrelated changes.
+
+## Scenario: production configuration deployment and alias verification
+
+### 1. Scope / Trigger
+
+Apply this contract whenever a production runtime capability depends on newly added or changed provider environment values. A deployment reaching `Ready` is necessary but does not prove that the primary production domain serves that deployment or receives those values.
+
+### 2. Signatures
+
+```text
+vercel env add <NAME> production --force [--sensitive]
+vercel env ls production
+vercel --prod --yes
+vercel inspect <immutable-deployment-or-primary-alias>
+vercel promote <immutable-deployment> --yes
+vercel alias set <immutable-deployment> <existing-primary-alias>
+```
+
+`vercel promote` and `vercel alias set` are external production actions. Run them only inside an explicitly authorized deployment boundary. Use `alias set` only when deployment-ID inspection proves promotion did not move the existing primary alias.
+
+### 3. Contracts
+
+- Secret values use provider-sensitive storage and must never be printed, committed, copied into evidence, or inferred as absent merely because `vercel env pull` omits them.
+- Verify environment registration by name, target, and provider metadata; verify effectiveness through the narrowest runtime behavior that depends on the value.
+- Resolve the intended public origin from the application's production-site contract, not from an immutable deployment URL or a regex that assumes the exported URL is a string literal.
+- After deployment, inspect both the immutable Ready deployment and the primary alias. Their deployment IDs must match before the rollout is reported as live.
+- A zero-write authenticated probe uses a fresh nonexistent synthetic identity, short-lived credentials, invented non-colliding input, same-origin headers, and before/after identity-scoped counts for every table the endpoint could mutate.
+- Evidence contains only response status/mode, aggregate row counts, token-presence booleans, cache-policy booleans, and before/after equality booleans. It never contains raw URLs, IDs, tokens, secrets, headers, or response bodies.
+
+### 4. Validation & Error Matrix
+
+| Condition | Required behavior |
+| --- | --- |
+| Sensitive value is absent from a pulled environment file but registered as sensitive | Treat omission as expected; do not replace it with a non-sensitive value. |
+| Deployment is Ready but primary-alias deployment ID differs | Do not claim rollout success or diagnose runtime behavior from the alias as if it were current. |
+| `promote` succeeds but IDs still differ | Stop; use an explicitly authorized `alias set` for the existing primary alias, then compare IDs again. |
+| Authenticated capability probe returns fail-closed `503 sync_off` | Verify alias routing and runtime environment delivery; never weaken mode or secret validation. |
+| Probe returns `401` | Inspect synthetic session encoding/cookie delivery without using a real session. |
+| Probe returns same-origin rejection | Compare the exact configured public origin and request origin. |
+| Probe succeeds but any scoped database count changes unexpectedly | Fail the gate and return the capability to its safe mode; do not issue compensating writes without review. |
+
+### 5. Good / Base / Bad Cases
+
+- **Good:** sensitive configuration is registered, a new deployment is Ready, the primary alias and immutable deployment IDs match, and one synthetic authenticated probe succeeds with exactly unchanged scoped counts.
+- **Base:** the endpoint remains fail-closed because configuration is intentionally absent; no deployment or alias action is needed.
+- **Bad:** a Ready deployment is assumed live, the stale primary alias returns `sync_off`, and the implementation's secret-length requirement is weakened instead of verifying routing.
+
+### 6. Tests Required
+
+- Unit-test capability configuration for exact allowed modes, missing values, short secrets, and newline-contaminated mode values.
+- Unit-test preview/write separation so a preview proposal cannot authorize a write-mode confirmation.
+- For an authorized production probe, assert the exact HTTP status and returned mode, aggregate row/skip counts, proposal-presence fields, private/no-store headers, and exact before/after equality across all potentially written tables.
+- Record alias-to-deployment identity equality separately from deployment readiness; neither assertion substitutes for the other.
+
+### 7. Wrong vs Correct
+
+#### Wrong
+
+```text
+Ready deployment + registered env names => production capability is live
+```
+
+#### Correct
+
+```text
+registered env metadata
+  + Ready immutable deployment
+  + primary alias resolves to the same deployment ID
+  + narrow runtime probe
+  + exact zero-write before/after proof
+  => production preview gate passes
+```

--- a/.trellis/tasks/07-28-roll-out-amex-sync-production/implement.md
+++ b/.trellis/tasks/07-28-roll-out-amex-sync-production/implement.md
@@ -3,7 +3,7 @@
 ## Operating Rules
 
 - This parent coordinates children and production gates; it does not own application code.
-- Keep production AMEX effectively `off` through children 1–4 and every unapproved child-5 boundary.
+- Keep production AMEX effectively `off` through children 1–4 and until the preview boundary receives separate authorization; preview authorization does not authorize userscript, provider, confirmation, or write actions.
 - Do not run the old `backfill:amex-catalog --apply`. Its per-user key writes are superseded even for the formerly accepted strict partial subset.
 - Database, deployment, configuration, userscript, provider, live-browser, and git-history actions require their own authorization and target verification.
 
@@ -51,7 +51,7 @@
 - [x] Reverify all development evidence and define production recovery/stop conditions.
 - [x] Obtain and record separate approvals for the completed production schema, catalog, and legacy-bridge boundaries.
 - [x] Obtain and record the reviewed main-release and automatic application-deployment authorization and verification.
-- [ ] Keep cleanup, preview, userscript, live-provider, and write boundaries independently unapproved until each receives its own later decision.
+- [x] Enable authenticated zero-write production preview only after its separate approval and prerequisite gates; keep cleanup, userscript, live-provider, and write boundaries independently unapproved until each receives its own later decision.
 - [x] Generate fresh sanitized evidence from the new operators; do not reuse historical counts as acceptance evidence.
 
 ## 3. Cross-child integration review
@@ -112,17 +112,18 @@ The following sanitized evidence is retained from the superseded rollout and rem
 - [ ] Separately gated production cleanup — not run.
 - [x] Main release and rollout-authorized automatic application deployment — completed through reviewed pull request #10 with AMEX `off`; no production configuration value changed.
 - [ ] Browser/live provider scan or userscript installation/publication — not run.
-- [ ] Production preview or write activation — not performed; AMEX remains effectively `off`.
+- [x] Production preview — separately authorized, configured with a sensitive HMAC, deployed, and authenticated as zero-write; AMEX now resolves to `preview`.
+- [ ] Production write activation — not performed.
 
 ## 6. Parent completion gate
 
 - [x] Children 1, 2, and 4 have verified development evidence and are eligible for completion/archive.
 - [ ] Child 3 remains pending only the separately gated cleanup deletion/recovery boundary.
 - [x] Child 5 records fresh development and completed production schema/catalog/bridge evidence without reusing historical per-user-key counts.
-- [ ] Child 5 remains `in_progress` pending release deployment, optional cleanup, preview, userscript/live-provider, write, and rollback-window boundaries.
+- [ ] Child 5 remains `in_progress` pending optional cleanup, userscript/live-provider, write, and rollback-window boundaries; release deployment and preview are complete.
 - [x] Production AMEX remained effectively `off` throughout the completed production database gates.
 - [ ] Legacy columns/ledger retention and any future removal are handed to a separate rollback-window task after rollout evidence exists.
 
 ## Current status
 
-Development validation and the separately authorized production target/recovery, additive schema, global catalog, exact legacy bridge, preservation, hybrid-parity, idempotent-replay, reviewed merge, automatic application deployment, and read-only smoke gates have passed. The parent remains `in_progress`; production AMEX remains effectively `off`. Cleanup, HMAC provisioning, preview, userscript/provider activity, live scanning, write activation, and rollback-window removal remain independent later gates.
+Development validation and the separately authorized production target/recovery, additive schema, global catalog, exact legacy bridge, preservation, hybrid-parity, idempotent-replay, reviewed merge, application deployment, anonymous smoke, and authenticated zero-write preview gates have passed. The parent remains `in_progress`; production AMEX now resolves to `preview`. Cleanup, userscript/provider activity, live scanning, write activation, and rollback-window removal remain independent later gates.

--- a/.trellis/tasks/07-29-production-global-benefit-rollout/implement.md
+++ b/.trellis/tasks/07-29-production-global-benefit-rollout/implement.md
@@ -4,11 +4,11 @@
 
 - [x] Children 1–4 are code-complete and their safe static/unit checks have been reviewed.
 - [x] Children 1–4 passed separately authorized verified development-database validation.
-- [x] Production AMEX remains effectively off.
+- [x] Production AMEX remained effectively off through the prerequisite gates before separately authorized preview enablement.
 - [x] Exact targets, stop conditions, point-in-time recovery, and a provider-native recovery branch without compute are verified before production migration.
 - [x] The superseded `backfill:amex-catalog --apply` is disabled and will not be invoked.
 
-**Current gate:** Production target/recovery, additive schema, global-catalog, legacy bridge, preservation, hybrid-parity, and idempotent-replay gates have passed under separate authorizations. Production AMEX remains `off`; push/deployment, cleanup, preview, and activation remain separately gated.
+**Current gate:** Production target/recovery, additive schema, global-catalog, legacy bridge, preservation, hybrid-parity, idempotent-replay, reviewed deployment, and authenticated zero-write preview gates have passed under separate authorizations. Production AMEX is `preview`; cleanup, userscript/provider activity, and write activation remain separately gated.
 
 ## 1. Review implementation evidence
 
@@ -76,8 +76,8 @@
 ## 7. Preview and userscript boundary
 
 - [x] Verify global AMEX authority deployment, exact target, migrations, and effective off state.
-- [ ] Separately provision production HMAC and configure preview without exposing values.
-- [ ] Redeploy through the approved path and prove authenticated preview is zero-write.
+- [x] Separately provision production HMAC and configure preview without exposing values.
+- [x] Redeploy through the approved path and prove authenticated preview is zero-write.
 - [ ] Build/audit and separately install the production userscript through the owner-approved procedure.
 - [ ] Obtain attended live-scan authorization and review sanitized proposed/unchanged/skipped/failed outcomes.
 - [ ] Require zero unexpected destination and no custom/unresolved/user-key authority.
@@ -117,8 +117,9 @@ git diff --check
 - [x] Production legacy bridge apply — completed under separate authorization; preservation, hybrid parity, and complete idempotent replay passed.
 - [ ] Production cleanup/rollback, seed, reset, or other database mutation — unperformed.
 - [x] Verified development-database migration/catalog/runtime/bridge/rollback-re-bridge/synthetic-AMEX validation — completed.
-- [ ] Browser/live AMEX, userscript installation/publication, production preview, or confirmation — unperformed.
-- [x] Main release and rollout-authorized automatic production deployment — completed through reviewed pull request #10 with AMEX still `off`; no production configuration value changed.
+- [ ] Browser/live AMEX, userscript installation/publication, or confirmation — unperformed.
+- [x] Production preview — configured with a sensitive HMAC, deployed, and verified through one authenticated synthetic HTTP 200 preview with zero proposal rows and exactly unchanged zero synthetic-user database counts.
+- [x] Main release and rollout-authorized automatic production deployment — completed through reviewed pull request #10 with AMEX `off`; the later separately authorized preview deployment reached Ready and the primary alias was verified against its deployment ID.
 - [x] Review branch push, pull-request review, merge, promoted production alias, anonymous core smoke, and post-deployment database invariants — passed.
 
 The database-backed usage-guide audit was inadvertently invoked during final source review and failed read-only against the expected unmigrated schema before returning rows. It was not retried and made no mutation. Operational commands run only after their exact authorization; a skipped or blocked gate is not passed.
@@ -134,4 +135,4 @@ The earlier production read-only inspection and per-user-key dry-run are preserv
 
 ## Current status
 
-Implementation, verified-development, production target/recovery, additive schema, global catalog, legacy bridge, preservation, hybrid parity, and idempotent replay gates passed. Pull request #10 was independently reviewed, corrected, merged, and automatically deployed; the promoted production alias and anonymous core routes passed smoke tests, and post-deployment catalog/bridge invariants remain exact. Legacy rows and links remain, cleanup is deferred, and production AMEX remains effectively `off`. Cleanup, HMAC provisioning, preview, userscript/provider activity, live scanning, and write activation remain later independent boundaries.
+Implementation, verified-development, production target/recovery, additive schema, global catalog, legacy bridge, preservation, hybrid parity, idempotent replay, reviewed deployment, anonymous smoke, and authenticated zero-write preview gates passed. The production primary alias is verified against the preview-configured Ready deployment; production AMEX resolves to `preview`, the successful synthetic response was HTTP 200 with zero proposal rows, and all ten synthetic-user-scoped database counts remained zero and exactly unchanged. Legacy rows and links remain and cleanup is deferred. Cleanup, userscript/provider activity, live scanning, confirmation, and write activation remain later independent boundaries.

--- a/.trellis/tasks/07-29-production-global-benefit-rollout/prd.md
+++ b/.trellis/tasks/07-29-production-global-benefit-rollout/prd.md
@@ -35,7 +35,7 @@ Operationally migrate and validate the global-benefit model in development and p
 - [x] Standard definitions are read-only, latest global terms are visible, and catalog additions reach existing active cards without state resets.
 - [x] The reviewed application release is merged and deployed with AMEX `off`; anonymous core smoke and post-deployment catalog/bridge invariants pass.
 - [x] The old per-user AMEX key apply is not executed and user keys have no runtime authority.
-- [ ] Preview is authenticated and zero-write; userscript installation/live scan are separately authorized and audited.
+- [x] Preview is authenticated and zero-write; userscript installation and live scan remain unperformed and separately gated.
 - [ ] Write, if authorized, is bounded and reconciles expected attempts/audits/provenance/status changes with no unrelated account effects.
 - [ ] Rollback to mode `off` and pre-cleanup bridge rollback are operationally verified; evidence is sanitized.
 

--- a/.trellis/tasks/07-29-production-global-benefit-rollout/research/production-amex-preview-2026-07-30.md
+++ b/.trellis/tasks/07-29-production-global-benefit-rollout/research/production-amex-preview-2026-07-30.md
@@ -1,0 +1,52 @@
+# Sanitized production AMEX preview verification — 2026-07-30
+
+## Authorization and scope
+
+The user selected the zero-write production preview boundary. This authorized publishing sanitized deployment evidence, provisioning a production AMEX HMAC key, setting mode to `preview`, redeploying, and issuing one controlled authenticated synthetic preview verification. It did not authorize a userscript installation or publication, provider scan, confirmation request, benefit-status write, cleanup, or production write mode.
+
+## Configuration and deployment
+
+- Production `AMEX_SYNC_MODE` is configured as the exact newline-free value `preview`.
+- A fresh production `AMEX_SYNC_HMAC_KEY` was generated in shell memory and sent directly to Vercel as a sensitive environment variable. It was not printed, written to the repository, or retained in a pulled environment file.
+- Both variable names are registered for the production environment.
+- The preview-configured deployment reached `Ready` in the production target.
+- The primary production domain initially remained attached to the preceding Ready deployment, so the first authenticated endpoint request failed closed with HTTP 503 `sync_off` and made no database writes.
+- Vercel's promotion command completed but did not move this project's custom primary-domain alias. The existing alias was therefore pointed explicitly at the already verified latest Ready production deployment, and deployment-ID comparison then proved they matched.
+
+## Synthetic authenticated verification
+
+The verification used a fresh nonexistent synthetic user identity, a 120-second synthetic NextAuth JWE, an invented five-digit ending, one synthetic card, and zero benefit rows. No real account, browser session, provider data, userscript, AMEX scan, or confirmation endpoint was used.
+
+The successful response had only these sanitized properties:
+
+- HTTP status: 200;
+- mode: `preview`;
+- proposal rows: 0;
+- card skips: 0, because the envelope contained no benefit rows requiring card mapping;
+- signed proposal token: present;
+- proposal expiry: present;
+- cache policy: private and no-store;
+- referrer policy: no-referrer.
+
+The JWT, proposal token, HMAC, NextAuth secret, production URL, synthetic identity, deployment identifiers, raw response body, and raw headers were never emitted or retained.
+
+## Zero-write proof
+
+Immediately before and after the successful request, synthetic-user-scoped counts were zero and exactly unchanged across:
+
+- `User`;
+- `Account`;
+- `Session`;
+- `CreditCard`;
+- `Benefit`;
+- `BenefitStatus`;
+- `ExternalCardMapping`;
+- `AmexSyncAttempt`;
+- `BenefitStatusSourceProvenance`;
+- `AmexSyncRowAudit`.
+
+The earlier fail-closed request also left the same scoped counts unchanged. No confirmation endpoint was called, so no status, attempt, audit, or provenance mutation was authorized or performed.
+
+## Current gate
+
+Production AMEX now resolves to `preview`, and the authenticated deployed preview endpoint has passed its zero-write gate. Cleanup, userscript installation/publication, live provider scanning, and `write` mode remain separate unapproved boundaries. A preview-mode proposal cannot authorize a later write-mode confirmation.

--- a/.trellis/tasks/07-29-production-global-benefit-rollout/research/production-amex-preview-2026-07-30.md
+++ b/.trellis/tasks/07-29-production-global-benefit-rollout/research/production-amex-preview-2026-07-30.md
@@ -22,7 +22,7 @@ The successful response had only these sanitized properties:
 - HTTP status: 200;
 - mode: `preview`;
 - proposal rows: 0;
-- card skips: 0, because the envelope contained no benefit rows requiring card mapping;
+- card skips: 0, because the fresh nonexistent synthetic identity owned no destination cards;
 - signed proposal token: present;
 - proposal expiry: present;
 - cache policy: private and no-store;

--- a/src/lib/amex-sync/__tests__/proposal-mode-request.test.ts
+++ b/src/lib/amex-sync/__tests__/proposal-mode-request.test.ts
@@ -77,6 +77,13 @@ describe("Amex sync mode", () => {
   ])("fails closed for configuration %#", (environment, expected) => {
     expect(resolveAmexSyncConfiguration(environment).mode).toBe(expected);
   });
+
+  it.each(["preview\n", "write\n"])("fails closed for newline-contaminated mode %p", (mode) => {
+    expect(resolveAmexSyncConfiguration({
+      AMEX_SYNC_MODE: mode,
+      AMEX_SYNC_HMAC_KEY: key,
+    })).toEqual({ mode: "off", hmacKey: null });
+  });
 });
 
 describe("HMAC-bound Amex sync proposal", () => {


### PR DESCRIPTION
## Summary
- record the separately authorized production AMEX preview configuration and deployment evidence
- document the authenticated synthetic zero-write verification and retained rollout boundaries
- add the durable Vercel deployment/primary-alias verification contract

## Verification
- strict TypeScript passed
- task-artifact consistency and Markdown review passed
- whitespace and sensitive-value scans passed
- no userscript, provider scan, confirmation request, or write-mode action was performed

🤖 Generated with [Claude Code](https://claude.com/claude-code)