### PR TITLE
docs: record production AMEX write activation

### DIFF
--- a/.trellis/tasks/07-28-roll-out-amex-sync-production/implement.md
+++ b/.trellis/tasks/07-28-roll-out-amex-sync-production/implement.md
@@ -51,7 +51,7 @@
 - [x] Reverify all development evidence and define production recovery/stop conditions.
 - [x] Obtain and record separate approvals for the completed production schema, catalog, and legacy-bridge boundaries.
 - [x] Obtain and record the reviewed main-release and automatic application-deployment authorization and verification.
-- [x] Enable authenticated zero-write production preview only after its separate approval and prerequisite gates; keep cleanup, userscript, live-provider, and write boundaries independently unapproved until each receives its own later decision.
+- [x] Enable authenticated zero-write production preview only after its separate approval and prerequisite gates; cleanup, userscript, live-provider, and write boundaries remained independently gated, and write configuration later received its own decision without authorizing confirmation.
 - [x] Generate fresh sanitized evidence from the new operators; do not reuse historical counts as acceptance evidence.
 
 ## 3. Cross-child integration review
@@ -112,18 +112,18 @@ The following sanitized evidence is retained from the superseded rollout and rem
 - [ ] Separately gated production cleanup — not run.
 - [x] Main release and rollout-authorized automatic application deployment — completed through reviewed pull request #10 with AMEX `off`; no production configuration value changed.
 - [ ] Browser/live provider scan or userscript installation/publication — not run.
-- [x] Production preview — separately authorized, configured with a sensitive HMAC, deployed, and authenticated as zero-write; AMEX now resolves to `preview`.
-- [ ] Production write activation — not performed.
+- [x] Production preview — separately authorized, configured with a sensitive HMAC, deployed, and authenticated as zero-write.
+- [x] Production write activation — separately authorized, configured on the exact production project, deployed Ready, and authenticated through a zero-write synthetic preview response returning mode `write`; no proposal was confirmed.
 
 ## 6. Parent completion gate
 
 - [x] Children 1, 2, and 4 have verified development evidence and are eligible for completion/archive.
 - [ ] Child 3 remains pending only the separately gated cleanup deletion/recovery boundary.
 - [x] Child 5 records fresh development and completed production schema/catalog/bridge evidence without reusing historical per-user-key counts.
-- [ ] Child 5 remains `in_progress` pending optional cleanup, userscript/live-provider, write, and rollback-window boundaries; release deployment and preview are complete.
+- [ ] Child 5 remains `in_progress` pending optional cleanup, userscript/live-provider activity, first confirmation, and rollback-window boundaries; release deployment, preview, and write configuration are complete.
 - [x] Production AMEX remained effectively `off` throughout the completed production database gates.
 - [ ] Legacy columns/ledger retention and any future removal are handed to a separate rollback-window task after rollout evidence exists.
 
 ## Current status
 
-Development validation and the separately authorized production target/recovery, additive schema, global catalog, exact legacy bridge, preservation, hybrid-parity, idempotent-replay, reviewed merge, application deployment, anonymous smoke, and authenticated zero-write preview gates have passed. The parent remains `in_progress`; production AMEX now resolves to `preview`. Cleanup, userscript/provider activity, live scanning, write activation, and rollback-window removal remain independent later gates.
+Development validation and the separately authorized production target/recovery, additive schema, global catalog, exact legacy bridge, preservation, hybrid-parity, idempotent-replay, reviewed merge, application deployment, anonymous smoke, authenticated zero-write preview, and write-configuration gates have passed. The parent remains `in_progress`; production AMEX now resolves to `write`, but no proposal has been confirmed. Cleanup, userscript/provider activity, live scanning, first confirmation, and rollback-window removal remain independent later gates.

--- a/.trellis/tasks/07-29-production-global-benefit-rollout/implement.md
+++ b/.trellis/tasks/07-29-production-global-benefit-rollout/implement.md
@@ -8,7 +8,7 @@
 - [x] Exact targets, stop conditions, point-in-time recovery, and a provider-native recovery branch without compute are verified before production migration.
 - [x] The superseded `backfill:amex-catalog --apply` is disabled and will not be invoked.
 
-**Current gate:** Production target/recovery, additive schema, global-catalog, legacy bridge, preservation, hybrid-parity, idempotent-replay, reviewed deployment, and authenticated zero-write preview gates have passed under separate authorizations. Production AMEX is `preview`; cleanup, userscript/provider activity, and write activation remain separately gated.
+**Current gate:** Production target/recovery, additive schema, global-catalog, legacy bridge, preservation, hybrid-parity, idempotent-replay, reviewed deployment, authenticated zero-write preview, and separately authorized write-configuration gates have passed. Production AMEX is `write`, but no proposal has been confirmed; cleanup, userscript/provider activity, real-account proposal review, and the first bounded confirmation remain separately gated.
 
 ## 1. Review implementation evidence
 
@@ -84,8 +84,8 @@
 
 ## 8. Write boundary
 
-- [ ] Present sanitized preview evidence and obtain a separate explicit write decision.
-- [ ] Enable write through the approved configuration/deployment path.
+- [x] Present sanitized preview evidence and obtain a separate explicit write decision.
+- [x] Enable write through the approved configuration/deployment path without confirming a proposal.
 - [ ] Perform one bounded explicit confirmation.
 - [ ] Reconcile attempt, row-audit, provenance, destination status, and unrelated-account aggregates.
 - [ ] Return mode off immediately on any mismatch; do not issue compensating repair writes without review.
@@ -119,7 +119,8 @@ git diff --check
 - [x] Verified development-database migration/catalog/runtime/bridge/rollback-re-bridge/synthetic-AMEX validation — completed.
 - [ ] Browser/live AMEX, userscript installation/publication, or confirmation — unperformed.
 - [x] Production preview — configured with a sensitive HMAC, deployed, and verified through one authenticated synthetic HTTP 200 preview with zero proposal rows and exactly unchanged zero synthetic-user database counts.
-- [x] Main release and rollout-authorized automatic production deployment — completed through reviewed pull request #10 with AMEX `off`; the later separately authorized preview deployment reached Ready and the primary alias was verified against its deployment ID.
+- [x] Production write activation — separately authorized after preview evidence, configured on the exact production project with a fresh sensitive HMAC, deployed Ready, and verified through an authenticated synthetic HTTP 200 response returning mode `write` with exactly unchanged zero database counts; no proposal was confirmed.
+- [x] Main release and rollout-authorized automatic production deployment — completed through reviewed pull request #10 with AMEX `off`; later separately authorized preview and write deployments reached Ready and their primary aliases were verified against deployment IDs.
 - [x] Review branch push, pull-request review, merge, promoted production alias, anonymous core smoke, and post-deployment database invariants — passed.
 
 The database-backed usage-guide audit was inadvertently invoked during final source review and failed read-only against the expected unmigrated schema before returning rows. It was not retried and made no mutation. Operational commands run only after their exact authorization; a skipped or blocked gate is not passed.
@@ -135,4 +136,4 @@ The earlier production read-only inspection and per-user-key dry-run are preserv
 
 ## Current status
 
-Implementation, verified-development, production target/recovery, additive schema, global catalog, legacy bridge, preservation, hybrid parity, idempotent replay, reviewed deployment, anonymous smoke, and authenticated zero-write preview gates passed. The production primary alias is verified against the preview-configured Ready deployment; production AMEX resolves to `preview`, the successful synthetic response was HTTP 200 with zero proposal rows, and all ten synthetic-user-scoped database counts remained zero and exactly unchanged. Legacy rows and links remain and cleanup is deferred. Cleanup, userscript/provider activity, live scanning, confirmation, and write activation remain later independent boundaries.
+Implementation, verified-development, production target/recovery, additive schema, global catalog, legacy bridge, preservation, hybrid parity, idempotent replay, reviewed deployment, anonymous smoke, authenticated zero-write preview, and separately authorized write-configuration gates passed. The production primary alias is verified against the Ready write-configured deployment; production AMEX resolves to `write`, the authenticated synthetic response was HTTP 200 with zero proposal rows, and all ten synthetic-user-scoped database counts remained zero and exactly unchanged. No proposal was confirmed. Legacy rows and links remain and cleanup is deferred. Cleanup, userscript/provider activity, live scanning, real-account proposal review, and the first bounded confirmation remain later independent boundaries.

--- a/.trellis/tasks/07-29-production-global-benefit-rollout/research/production-amex-write-activation-2026-07-31.md
+++ b/.trellis/tasks/07-29-production-global-benefit-rollout/research/production-amex-write-activation-2026-07-31.md
@@ -1,0 +1,59 @@
+# Sanitized production AMEX write activation — 2026-07-31
+
+## Authorization and scope
+
+After reviewing the authenticated zero-write preview evidence, the user explicitly selected **Enable write, no confirm**. This authorized changing the verified production AMEX mode to `write`, provisioning the required production-project HMAC, redeploying, and verifying runtime effectiveness without confirmation. It did not authorize userscript installation or publication, a provider scan, a real-account proposal, the confirmation endpoint, a benefit-status mutation, cleanup, or compensating writes.
+
+## Immediate target verification
+
+- The repository was on clean `main`, and the generic build remained migration-free.
+- The first preflight correctly stopped because the repository's local Vercel link was not the project serving the production primary domain. No configuration changed during that failed precondition check.
+- An isolated temporary Vercel link then verified the exact production project, Ready primary alias, and currently served deployment without modifying the repository's local Vercel link.
+- The production project did not expose explicit AMEX variable registrations through its project environment listing. No secret was copied or inferred from the differently linked project.
+- A fresh HMAC was generated in shell memory and registered directly on the verified production project as sensitive. It was never printed, persisted, or written to a pulled environment file.
+- `AMEX_SYNC_MODE` was registered as the exact newline-free value `write`.
+
+## Deployment and rollback
+
+- The currently served Ready preview deployment was retained as the rollback target.
+- The same reviewed source revision was rebuilt for the production target after the production-project variables were registered; the retained immutable deployment remained unchanged.
+- The new deployment reached Ready, and deployment-ID comparison proved that the primary production alias served it.
+- No schema migration, catalog operation, legacy migration, cleanup, seed, reset, userscript action, browser action, provider action, or database mutation occurred during configuration and deployment.
+
+## Authenticated no-confirm verification
+
+Runtime effectiveness was verified with a fresh nonexistent synthetic identity, a 120-second synthetic NextAuth JWE, an invented five-digit ending, one synthetic card, and zero benefit rows. The preview endpoint was called once; the confirmation endpoint was never called.
+
+The successful response had only these sanitized properties:
+
+- HTTP status: 200;
+- mode: `write`;
+- proposal rows: 0;
+- card skips: 0 because the synthetic identity owned no destination cards;
+- signed proposal token: present;
+- proposal expiry: present;
+- cache policy: private and no-store;
+- referrer policy: no-referrer.
+
+The JWT, proposal token, HMAC, NextAuth secret, production URL, synthetic identity, deployment identifiers, database identity, raw response body, and raw headers were never emitted or retained.
+
+## Zero-write proof
+
+Immediately before and after the request, synthetic-user-scoped counts were zero and exactly unchanged across:
+
+- `User`;
+- `Account`;
+- `Session`;
+- `CreditCard`;
+- `Benefit`;
+- `BenefitStatus`;
+- `ExternalCardMapping`;
+- `AmexSyncAttempt`;
+- `BenefitStatusSourceProvenance`;
+- `AmexSyncRowAudit`.
+
+No proposal was confirmed, so no attempt, row audit, provenance, or status mutation was authorized or performed.
+
+## Current gate
+
+Production AMEX now resolves to `write`, and the deployed preview endpoint proves the runtime received that mode while remaining zero-write without confirmation. Userscript installation/publication, live provider scanning, real-account proposal review, and the first bounded confirmation remain separate unperformed boundaries. Cleanup also remains separately gated.


### PR DESCRIPTION
## Summary
- record the separately authorized production AMEX write-mode configuration and deployment
- document the authenticated no-confirm runtime verification and exact zero-write evidence
- preserve the remaining userscript, provider-scan, confirmation, cleanup, and rollback boundaries

## Verification
- strict TypeScript passed
- task-artifact consistency and Markdown review passed
- whitespace and sensitive-value scans passed
- no userscript, provider scan, confirmation request, benefit-status write, or cleanup was performed

🤖 Generated with [Claude Code](https://claude.com/claude-code)