### PR TITLE
Add the Bilt Card 2.0 lineup to the Catalog

### DIFF
--- a/card-templates/examples/bilt-blue-2026.json
+++ b/card-templates/examples/bilt-blue-2026.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "../schema.json",
+  "name": "Bilt Blue Card",
+  "issuer": "Bilt",
+  "annualFee": 0,
+  "imageUrl": "/images/cards/bilt-blue.png",
+  "sources": [
+    {
+      "label": "Bilt newsroom: Meet Bilt Card 2.0",
+      "url": "https://newsroom.biltrewards.com/meetbiltcard2.0",
+      "accessed": "2026-08-27"
+    },
+    {
+      "label": "Doctor of Credit: Three brand new Bilt 2.0 cards",
+      "url": "https://www.doctorofcredit.com/three-brand-new-bilt-2-0-cards-blue-obsidian-palladium/",
+      "accessed": "2026-08-27"
+    }
+  ],
+  "benefits": [],
+  "reviewNotes": "Entry tier of the Bilt Card 2.0 lineup launched 2026-02-07. No annual fee and no recurring trackable statement credits. The $100 Bilt Cash account-opening offer is a welcome bonus, not a recurring benefit, so it is intentionally omitted. 4% Bilt Cash earning is an earning multiplier and is excluded per contributor rules. Image is unset pending licensed card artwork."
+}

--- a/card-templates/examples/bilt-obsidian-2026.json
+++ b/card-templates/examples/bilt-obsidian-2026.json
@@ -1,0 +1,47 @@
+{
+  "$schema": "../schema.json",
+  "name": "Bilt Obsidian Card",
+  "issuer": "Bilt",
+  "annualFee": 95,
+  "imageUrl": "/images/cards/bilt-obsidian.png",
+  "sources": [
+    {
+      "label": "Bilt newsroom: Meet Bilt Card 2.0",
+      "url": "https://newsroom.biltrewards.com/meetbiltcard2.0",
+      "accessed": "2026-08-27"
+    },
+    {
+      "label": "Doctor of Credit: Three brand new Bilt 2.0 cards",
+      "url": "https://www.doctorofcredit.com/three-brand-new-bilt-2-0-cards-blue-obsidian-palladium/",
+      "accessed": "2026-08-27"
+    },
+    {
+      "label": "Upgraded Points: Bilt new credit card details",
+      "url": "https://upgradedpoints.com/news/bilt-new-credit-card-details/",
+      "accessed": "2026-08-27"
+    }
+  ],
+  "benefits": [
+    {
+      "description": "$50 Semi-Annual Bilt Travel Hotel Credit (Jan-Jun)",
+      "category": "Travel",
+      "maxAmount": 50,
+      "frequency": "YEARLY",
+      "cycleAlignment": "CALENDAR_FIXED",
+      "fixedCycleStartMonth": 1,
+      "fixedCycleDurationMonths": 6,
+      "notes": "Requires a minimum two-night stay booked through the Bilt Travel portal."
+    },
+    {
+      "description": "$50 Semi-Annual Bilt Travel Hotel Credit (Jul-Dec)",
+      "category": "Travel",
+      "maxAmount": 50,
+      "frequency": "YEARLY",
+      "cycleAlignment": "CALENDAR_FIXED",
+      "fixedCycleStartMonth": 7,
+      "fixedCycleDurationMonths": 6,
+      "notes": "Requires a minimum two-night stay booked through the Bilt Travel portal."
+    }
+  ],
+  "reviewNotes": "Mid tier of the Bilt Card 2.0 lineup launched 2026-02-07. The $100 annual Bilt Travel hotel credit is issued as two $50 credits that reset on calendar halves, so it is modeled as two CALENDAR_FIXED six-month benefits matching the existing Chase Sapphire Reserve semi-annual pattern. The $200 Bilt Cash account-opening offer is a welcome bonus and is omitted. Image is unset pending licensed card artwork."
+}

--- a/card-templates/examples/bilt-palladium-2026.json
+++ b/card-templates/examples/bilt-palladium-2026.json
@@ -1,0 +1,57 @@
+{
+  "$schema": "../schema.json",
+  "name": "Bilt Palladium Card",
+  "issuer": "Bilt",
+  "annualFee": 495,
+  "imageUrl": "/images/cards/bilt-palladium.png",
+  "sources": [
+    {
+      "label": "Bilt newsroom: Meet Bilt Card 2.0",
+      "url": "https://newsroom.biltrewards.com/meetbiltcard2.0",
+      "accessed": "2026-08-27"
+    },
+    {
+      "label": "Doctor of Credit: Three brand new Bilt 2.0 cards",
+      "url": "https://www.doctorofcredit.com/three-brand-new-bilt-2-0-cards-blue-obsidian-palladium/",
+      "accessed": "2026-08-27"
+    },
+    {
+      "label": "Upgraded Points: Bilt new credit card details",
+      "url": "https://upgradedpoints.com/news/bilt-new-credit-card-details/",
+      "accessed": "2026-08-27"
+    }
+  ],
+  "benefits": [
+    {
+      "description": "$200 Semi-Annual Bilt Travel Hotel Credit (Jan-Jun)",
+      "category": "Travel",
+      "maxAmount": 200,
+      "frequency": "YEARLY",
+      "cycleAlignment": "CALENDAR_FIXED",
+      "fixedCycleStartMonth": 1,
+      "fixedCycleDurationMonths": 6,
+      "notes": "Requires a minimum two-night stay booked through the Bilt Travel portal."
+    },
+    {
+      "description": "$200 Semi-Annual Bilt Travel Hotel Credit (Jul-Dec)",
+      "category": "Travel",
+      "maxAmount": 200,
+      "frequency": "YEARLY",
+      "cycleAlignment": "CALENDAR_FIXED",
+      "fixedCycleStartMonth": 7,
+      "fixedCycleDurationMonths": 6,
+      "notes": "Requires a minimum two-night stay booked through the Bilt Travel portal."
+    },
+    {
+      "description": "$200 Annual Bilt Cash Credit",
+      "category": "Bonus",
+      "maxAmount": 200,
+      "frequency": "YEARLY",
+      "cycleAlignment": "CALENDAR_FIXED",
+      "fixedCycleStartMonth": 1,
+      "fixedCycleDurationMonths": 12,
+      "notes": "Bilt Cash expires on December 31 each calendar year; up to $100 carries into the following year."
+    }
+  ],
+  "reviewNotes": "Premium tier of the Bilt Card 2.0 lineup launched 2026-02-07. The $400 annual Bilt Travel hotel credit is issued as two $200 credits resetting on calendar halves. The $200 annual Bilt Cash deposit is modeled CALENDAR_FIXED rather than CARD_ANNIVERSARY because Bilt Cash expires December 31 regardless of when it was deposited, so a calendar window is what the cardholder must actually spend against; reviewers should confirm against issuer terms. Priority Pass membership is always-on lounge access and is excluded per contributor rules. The $300 Bilt Cash account-opening offer is a welcome bonus and is omitted."
+}

--- a/src/lib/catalog/__tests__/synchronizer.test.ts
+++ b/src/lib/catalog/__tests__/synchronizer.test.ts
@@ -83,8 +83,8 @@ describe("global catalog synchronization", () => {
     const existing = snapshot();
     const plan = planCatalogSynchronization({ source: predefinedCardsData, snapshot: existing });
     expect(summarizeCatalogSyncPlan(plan)).toEqual({
-      cards: { create: 0, adopt: 0, update: 0, retire: 0, unchanged: 34 },
-      benefits: { create: 0, adopt: 0, update: 0, retire: 0, unchanged: 129 },
+      cards: { create: 0, adopt: 0, update: 0, retire: 0, unchanged: 37 },
+      benefits: { create: 0, adopt: 0, update: 0, retire: 0, unchanged: 134 },
       conflictCount: 0,
     });
     expect(plan.cards.filter((action) => action.existing).map((action) => action.existing!.id))
@@ -97,8 +97,8 @@ describe("global catalog synchronization", () => {
     existing.benefits.forEach((benefit) => { benefit.catalogKey = null; });
     const plan = planCatalogSynchronization({ source: predefinedCardsData, snapshot: existing });
     expect(summarizeCatalogSyncPlan(plan)).toEqual(expect.objectContaining({
-      cards: expect.objectContaining({ adopt: 34, create: 0 }),
-      benefits: expect.objectContaining({ adopt: 129, create: 0 }),
+      cards: expect.objectContaining({ adopt: 37, create: 0 }),
+      benefits: expect.objectContaining({ adopt: 134, create: 0 }),
       conflictCount: 0,
     }));
   });
@@ -263,7 +263,7 @@ describe("global catalog synchronization", () => {
     const report = await runGlobalCatalogSyncOperator({ source: predefinedCardsData, database: client });
     expect(report).toEqual(expect.objectContaining({
       mode: "dry-run",
-      source: { cards: 34, benefits: 129 },
+      source: { cards: 37, benefits: 134 },
       plan: expect.objectContaining({ conflictCount: 0 }),
     }));
     expect(client.predefinedCard.create).not.toHaveBeenCalled();
@@ -305,11 +305,11 @@ describe("global catalog synchronization", () => {
       confirmApply: GLOBAL_CATALOG_SYNC_CONFIRMATION,
       now: UPDATED_AT,
     });
-    expect(report.plan.cards.create).toBe(34);
-    expect(report.plan.benefits.create).toBe(129);
+    expect(report.plan.cards.create).toBe(37);
+    expect(report.plan.benefits.create).toBe(134);
     expect(client.$transaction).toHaveBeenCalledWith(expect.any(Function), { isolationLevel: "Serializable" });
-    expect(client.predefinedCard.create).toHaveBeenCalledTimes(34);
-    expect(client.predefinedBenefit.create).toHaveBeenCalledTimes(129);
+    expect(client.predefinedCard.create).toHaveBeenCalledTimes(37);
+    expect(client.predefinedBenefit.create).toHaveBeenCalledTimes(134);
   });
 
   it("rechecks the complete snapshot inside the transaction before any writer call", async () => {

--- a/src/lib/catalog/__tests__/validation.test.ts
+++ b/src/lib/catalog/__tests__/validation.test.ts
@@ -9,8 +9,8 @@ function copyCatalog(): StaticPredefinedCard[] {
 describe("global static catalog validation", () => {
   it("validates every explicit identity and preserves AMEX invariants", () => {
     expect(validateStaticCatalog(predefinedCardsData)).toEqual({
-      cards: 34,
-      benefits: 129,
+      cards: 37,
+      benefits: 134,
       amexCards: 12,
       amexBenefits: 56,
       amexWritableBenefits: 47,
@@ -26,7 +26,7 @@ describe("global static catalog validation", () => {
     card.benefits[0].description = "Rewritten current benefit terms";
     card.benefits = [...card.benefits].reverse();
 
-    expect(validateStaticCatalog(catalog)).toEqual(expect.objectContaining({ cards: 34, benefits: 129 }));
+    expect(validateStaticCatalog(catalog)).toEqual(expect.objectContaining({ cards: 37, benefits: 134 }));
     expect(card.catalogKey).toBe(originalCardKey);
     expect(card.benefits.map((benefit) => benefit.catalogKey).sort()).toEqual(originalBenefitKeys);
   });

--- a/src/lib/static-catalog.ts
+++ b/src/lib/static-catalog.ts
@@ -52,7 +52,7 @@ export interface PublicStaticCard extends Omit<StaticPredefinedCard, 'benefits'>
   updatedAt: string;
 }
 
-export const STATIC_CATALOG_UPDATED_AT = '2026-06-26';
+export const STATIC_CATALOG_UPDATED_AT = '2026-08-27';
 
 export const predefinedCardsData = [
     {
@@ -964,6 +964,94 @@ export const predefinedCardsData = [
           percentage: 0,
           cycleAlignment: 'CARD_ANNIVERSARY',
           fixedCycleDurationMonths: 48, // 4 years
+        },
+      ],
+    },
+    {
+      catalogKey: 'card:bilt-blue',
+      name: 'Bilt Blue Card',
+      issuer: 'Bilt',
+      annualFee: 0,
+      imageUrl: null,
+      benefits: [],
+    },
+    {
+      catalogKey: 'card:bilt-obsidian',
+      name: 'Bilt Obsidian Card',
+      issuer: 'Bilt',
+      annualFee: 95,
+      imageUrl: null,
+      benefits: [
+        {
+          catalogKey: 'benefit:bilt-obsidian:50-semi-annual-bilt-travel-hotel-credit-jan-jun',
+          parentCatalogKey: 'card:bilt-obsidian',
+          description: '$50 Semi-Annual Bilt Travel Hotel Credit (Jan-Jun)',
+          category: 'Travel',
+          maxAmount: 50,
+          frequency: 'YEARLY',
+          percentage: 0,
+          cycleAlignment: 'CALENDAR_FIXED',
+          fixedCycleStartMonth: 1, // Jan-Jun window
+          fixedCycleDurationMonths: 6,
+        },
+        {
+          catalogKey: 'benefit:bilt-obsidian:50-semi-annual-bilt-travel-hotel-credit-jul-dec',
+          parentCatalogKey: 'card:bilt-obsidian',
+          description: '$50 Semi-Annual Bilt Travel Hotel Credit (Jul-Dec)',
+          category: 'Travel',
+          maxAmount: 50,
+          frequency: 'YEARLY',
+          percentage: 0,
+          cycleAlignment: 'CALENDAR_FIXED',
+          fixedCycleStartMonth: 7, // Jul-Dec window
+          fixedCycleDurationMonths: 6,
+        },
+      ],
+    },
+    {
+      catalogKey: 'card:bilt-palladium',
+      name: 'Bilt Palladium Card',
+      issuer: 'Bilt',
+      annualFee: 495,
+      imageUrl: null,
+      benefits: [
+        {
+          catalogKey: 'benefit:bilt-palladium:200-semi-annual-bilt-travel-hotel-credit-jan-jun',
+          parentCatalogKey: 'card:bilt-palladium',
+          description: '$200 Semi-Annual Bilt Travel Hotel Credit (Jan-Jun)',
+          category: 'Travel',
+          maxAmount: 200,
+          frequency: 'YEARLY',
+          percentage: 0,
+          cycleAlignment: 'CALENDAR_FIXED',
+          fixedCycleStartMonth: 1, // Jan-Jun window
+          fixedCycleDurationMonths: 6,
+        },
+        {
+          catalogKey: 'benefit:bilt-palladium:200-semi-annual-bilt-travel-hotel-credit-jul-dec',
+          parentCatalogKey: 'card:bilt-palladium',
+          description: '$200 Semi-Annual Bilt Travel Hotel Credit (Jul-Dec)',
+          category: 'Travel',
+          maxAmount: 200,
+          frequency: 'YEARLY',
+          percentage: 0,
+          cycleAlignment: 'CALENDAR_FIXED',
+          fixedCycleStartMonth: 7, // Jul-Dec window
+          fixedCycleDurationMonths: 6,
+        },
+        {
+          // Bilt Cash expires December 31 regardless of deposit date, so the
+          // trackable window is the calendar year rather than the anniversary.
+          catalogKey: 'benefit:bilt-palladium:200-annual-bilt-cash-credit',
+          parentCatalogKey: 'card:bilt-palladium',
+          description: '$200 Annual Bilt Cash Credit',
+          category: 'Bonus',
+          maxAmount: 200,
+          frequency: 'YEARLY',
+          percentage: 0,
+          cycleAlignment: 'CALENDAR_FIXED',
+          fixedCycleStartMonth: 1,
+          fixedCycleDurationMonths: 12,
         },
       ],
     },


### PR DESCRIPTION
## Summary

Adds the three cards of the Bilt Card 2.0 lineup to the static Catalog. Bilt is
currently absent from the Catalog entirely.

The lineup changed materially in 2026: the Wells Fargo-issued Bilt Mastercard
sunset on 2026-02-06, and Bilt relaunched on 2026-02-07 with three cards issued
by Column N.A. (serviced by Cardless). This adds the current lineup only; the
retired Wells Fargo product is intentionally not modeled.

| Card | Annual fee | Trackable benefits |
| --- | --- | --- |
| Bilt Blue Card | $0 | 0 |
| Bilt Obsidian Card | $95 | 2 |
| Bilt Palladium Card | $495 | 3 |

Catalog totals move from 34 cards / 129 benefits to 37 / 134.

## Modeling decisions

- **Semi-annual hotel credits.** Obsidian's $100 and Palladium's $400 Bilt Travel
  hotel credits are both issued as two equal credits that reset on calendar
  halves. Each is modeled as two `CALENDAR_FIXED` six-month benefits, matching
  the existing Chase Sapphire Reserve semi-annual pattern rather than inventing
  a new frequency.
- **Palladium's $200 annual Bilt Cash** is modeled `CALENDAR_FIXED` starting in
  January rather than `CARD_ANNIVERSARY`, because Bilt Cash expires December 31
  regardless of when it was deposited. The calendar year is the window the
  cardholder actually has to spend against. Flagged in the template review notes
  in case maintainers read the issuer terms differently.
- **Bilt Blue has an empty `benefits` array**, following the existing Chase Ink
  Business Preferred precedent. It carries no recurring trackable credit but is
  still worth tracking as a $0-fee physical card.

## Deliberately excluded

- **Priority Pass** (Palladium) — always-on lounge access, excluded per the
  contributor rules on always-on access.
- **Account-opening Bilt Cash** ($100 / $200 / $300 by tier) — welcome bonuses,
  not recurring benefits.
- **4% Bilt Cash earning** — an earning multiplier, not a trackable credit.

## Sources

- Bilt newsroom, "Meet Bilt Card 2.0" — https://newsroom.biltrewards.com/meetbiltcard2.0
- Doctor of Credit — https://www.doctorofcredit.com/three-brand-new-bilt-2-0-cards-blue-obsidian-palladium/
- Upgraded Points — https://upgradedpoints.com/news/bilt-new-credit-card-details/

Accessed 2026-08-27. Recorded in each contributor template under `sources`.

## Card art

No card art is included: all three cards use `imageUrl: null` and fall back to
the placeholder icon in the card picker (verified locally).

Bilt Card 2.0 only launched 2026-02-07, and I could not find art meeting the bar
in `docs/card-image-ingestion.md` — issuer-hosted or known product-card-art, no
screenshots, comparison graphics, or cropped wallet photos. Rather than commit
artwork of uncertain provenance to a public repository, I have left this out and
run no part of `scripts/download-card-image.js`, so `manifest.json` and
`docs/card-image-sources.md` are untouched.

Happy to follow up with a separate, provenance-recorded PR if you can point me at
an acceptable source.

## Validation

- `npm run card-template:validate` — 4 templates validated
- `npx tsc --noEmit` — clean
- `npm test -- --runInBand` — 770/770 passing, including the updated Catalog
  invariant counts in `validation.test.ts` and `synchronizer.test.ts`

I have not run any database synchronization. Per
`card-templates/README.md` and the Catalog and Benefit Updates specification,
the global sync plan, existing-Physical-Card status propagation, and Benefit
Usage Guide disposition are maintainer decisions, so this PR changes only the
checked-in Catalog source and its contributor templates.
