### PR TITLE
fix: capture catalog sync report as json

### DIFF
--- a/.github/workflows/global-catalog-sync.yml
+++ b/.github/workflows/global-catalog-sync.yml
@@ -48,7 +48,7 @@ jobs:
         env:
           DATABASE_URL: ${{ secrets.CATALOG_SYNC_DATABASE_URL }}
         run: |
-          if ! npm run sync:global-catalog -- --dry-run > catalog-sync-report.json 2>catalog-sync-error.log; then
+          if ! npm run --silent sync:global-catalog -- --dry-run > catalog-sync-report.json 2>catalog-sync-error.log; then
             echo "Catalog sync dry-run failed." >&2
             exit 1
           fi
@@ -88,7 +88,7 @@ jobs:
         env:
           DATABASE_URL: ${{ secrets.CATALOG_SYNC_DATABASE_URL }}
         run: |
-          if ! npm run sync:global-catalog -- \
+          if ! npm run --silent sync:global-catalog -- \
               --apply \
               --target-verified \
               --confirm=SYNC_GLOBAL_CATALOG > catalog-sync-report.json 2>catalog-sync-error.log; then

--- a/scripts/check-catalog-sync-workflow.mjs
+++ b/scripts/check-catalog-sync-workflow.mjs
@@ -26,6 +26,7 @@ const requiredFragments = [
   "Record aggregate dry-run result",
   "2>catalog-sync-error.log",
   "stop without compensating writes",
+  "npm run --silent sync:global-catalog",
 ];
 for (const fragment of requiredFragments) {
   if (!workflow.includes(fragment)) throw new Error(`Catalog sync workflow is missing: ${fragment}`);


### PR DESCRIPTION
Fix the merged catalog-sync workflow to use npm --silent so the captured report remains valid JSON. The prior Neon preview test passed target verification but stopped before any database operation because npm's banner polluted the report file. Validation: npm run check:catalog-sync-workflow and git diff --check.