### PR TITLE
Deprecate Not Usable and add Ignored tracking tab

### DIFF
--- a/.trellis/tasks/08-16-activate-amex-sync-for-users/research/legacy-not-usable-to-ignore.md
+++ b/.trellis/tasks/08-16-activate-amex-sync-for-users/research/legacy-not-usable-to-ignore.md
@@ -1,0 +1,64 @@
+# Research: legacy not-usable rows to IGNORE
+
+- Query: Safest migration and projection changes for replacing `BenefitStatus.isNotUsable` with cycle-independent `BenefitTrackingPreference(mode=IGNORE)`.
+- Scope: internal
+- Date: 2026-08-31
+
+## Findings
+
+`BenefitTrackingPreference` was introduced by migration `prisma/migrations/20260827000000_add_benefit_tracking_preferences/migration.sql`. Its target-shape check allows exactly either `(creditCardId, predefinedBenefitId)` with `benefitId IS NULL` (standard, including bridge statuses where global identity wins) or `benefitId` alone (custom/legacy). Unique indexes are `BenefitTrackingPreference_standard_key (userId, creditCardId, predefinedBenefitId)` and `BenefitTrackingPreference_custom_key (userId, benefitId)`; both are usable as PostgreSQL `ON CONFLICT` targets. Existing preference rows may be TRACK, AUTO_CLAIM, or IGNORE, so a backfill must upsert and force mode to IGNORE rather than blindly insert.
+
+Recommended data mapping (inside one migration transaction):
+
+```sql
+-- Standard / bridge rows: global identity wins over retained legacy benefitId.
+INSERT INTO "BenefitTrackingPreference"
+  ("id", "userId", "creditCardId", "predefinedBenefitId", "benefitId", "mode", "createdAt", "updatedAt")
+SELECT
+  md5('legacy-not-usable:standard:' || s."userId" || ':' || s."creditCardId" || ':' || s."predefinedBenefitId"),
+  s."userId", s."creditCardId", s."predefinedBenefitId", NULL, 'IGNORE', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
+FROM (
+  SELECT DISTINCT "userId", "creditCardId", "predefinedBenefitId"
+  FROM "BenefitStatus"
+  WHERE "isNotUsable" = true
+    AND "creditCardId" IS NOT NULL
+    AND "predefinedBenefitId" IS NOT NULL
+) s
+ON CONFLICT ("userId", "creditCardId", "predefinedBenefitId") DO UPDATE
+SET "mode" = 'IGNORE', "updatedAt" = CURRENT_TIMESTAMP;
+
+-- Custom/legacy rows (no global identity).
+INSERT INTO "BenefitTrackingPreference"
+  ("id", "userId", "creditCardId", "predefinedBenefitId", "benefitId", "mode", "createdAt", "updatedAt")
+SELECT
+  md5('legacy-not-usable:custom:' || s."userId" || ':' || s."benefitId"),
+  s."userId", NULL, NULL, s."benefitId", 'IGNORE', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
+FROM (
+  SELECT DISTINCT "userId", "benefitId"
+  FROM "BenefitStatus"
+  WHERE "isNotUsable" = true
+    AND "predefinedBenefitId" IS NULL
+    AND "benefitId" IS NOT NULL
+) s
+ON CONFLICT ("userId", "benefitId") DO UPDATE
+SET "mode" = 'IGNORE', "updatedAt" = CURRENT_TIMESTAMP;
+
+-- Clear the cycle-local flag after preferences are materialized. Keep all
+-- completion/amount/cycle/timestamp fields unchanged.
+UPDATE "BenefitStatus" SET "isNotUsable" = false WHERE "isNotUsable" = true;
+```
+
+`md5` is built into PostgreSQL and avoids assuming `pgcrypto`; preference IDs are opaque text (the Prisma `cuid()` default is not a database constraint). If the project requires CUID-format IDs, use an explicitly authorized Prisma data-migration/operator instead; do not silently add a database extension. Invalid source-less rows, or rows with only `predefinedBenefitId` and no `creditCardId`, cannot satisfy the preference target check and should be skipped/reported rather than assigned a guessed key.
+
+The dashboard already has a canonical IGNORE path: `buildBenefitDashboardProjection` calls `excludeIgnoredBenefits` before partitioning (`src/lib/benefit-dashboard.ts:295-301`), and `fetchTrackedBenefitStatuses` also filters IGNORE for read surfaces (`src/lib/benefit-tracking-preferences.ts:95-116`). Once the backfill sets preferences, historical not-usable rows disappear from all user-facing projections. Clearing `isNotUsable` additionally prevents `fetchDashboardBenefitStatuses` (`src/lib/benefit-dashboard.ts:352-357`) from retaining closed historical rows via its `status.isNotUsable` inclusion branch.
+
+The current projection/client still exposes `notUsableBenefits`, `totalNotUsableValue`, a Not Usable tab/card, and partitioning logic (`src/lib/benefit-dashboard.ts:39-45, 187-196`; `src/components/BenefitsDisplayClient.tsx:17-45, 647-740`). Fully adopting IGNORE means removing those UI/projection fields and tests, while keeping IGNORE preferences and settings reset as the only restoration path. The `BenefitStatus.isNotUsable` column is still read by AMEX sync/audit/reconciliation and repair tooling (`src/lib/amex-sync/*`, `src/lib/global-benefit-category-repair*`); dropping the column/schema now would be a broad migration and risks those contracts. Prefer retaining the column as compatibility/audit state, but stop exposing it in dashboard reads and remove its mutation/UI action.
+
+`setBenefitTrackingModeAction` already updates an existing preference or creates one and scopes standard/custom keys (`src/app/benefits/actions.ts:833-880`), so the backfill should match those exact identities. The action currently clears `isNotUsable` only for AUTO_CLAIM (`src/app/benefits/actions.ts:883-893`); after migration, IGNORE rows should simply have the flag false and be filtered by preference.
+
+## Caveats / Not Found
+
+- No existing checked-in data-migration script/backfill targets `BenefitTrackingPreference`; prior migrations use raw SQL updates but do not establish a reusable CUID generator.
+- Prisma's composite uniqueness with nullable columns is safe here because the target-shape CHECK constraint forces one non-null key shape; malformed legacy statuses must not be migrated by inference.
+- The migration changes only `isNotUsable`; preserve `isCompleted`, `usedAmount`, cycle coordinates, completion timestamps, and status IDs. Updating `BenefitStatus.updatedAt` is optional and would alter historical timestamps; omit it unless the product explicitly wants that audit signal.
+- Existing IGNORE preferences remain IGNORE; existing AUTO_CLAIM/TRACK preferences for a not-usable target are intentionally overridden to IGNORE to satisfy the requested deprecation semantics.

--- a/prisma/migrations/20260831000000_migrate_not_usable_to_ignore/migration.sql
+++ b/prisma/migrations/20260831000000_migrate_not_usable_to_ignore/migration.sql
@@ -20,6 +20,48 @@ BEGIN
   END IF;
 END $$;
 
+-- Do not manufacture a preference for a row whose related physical card is
+-- owned by another user (or missing). The effective-benefit reader rejects
+-- that relationship, so guessing here would either strand the preference or
+-- hide a malformed status instead of failing closed.
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM "BenefitStatus" status
+    LEFT JOIN "CreditCard" card ON card."id" = status."creditCardId"
+    WHERE status."isNotUsable" = true
+      AND status."predefinedBenefitId" IS NOT NULL
+      AND (card."id" IS NULL OR card."userId" <> status."userId")
+  ) THEN
+    RAISE EXCEPTION 'Cannot migrate not-usable status with cross-owner or missing standard card';
+  END IF;
+END $$;
+
+-- Custom rows may carry a card through either the status or its legacy
+-- definition. Reject a cross-owner/missing card, while retaining support for
+-- standalone legacy definitions whose Benefit.userId is intentionally NULL.
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM "BenefitStatus" status
+    JOIN "Benefit" benefit ON benefit."id" = status."benefitId"
+    LEFT JOIN "CreditCard" card
+      ON card."id" = COALESCE(status."creditCardId", benefit."creditCardId")
+    WHERE status."isNotUsable" = true
+      AND status."predefinedBenefitId" IS NULL
+      AND status."benefitId" IS NOT NULL
+      AND (
+        (benefit."userId" IS NOT NULL AND benefit."userId" <> status."userId")
+        OR (COALESCE(status."creditCardId", benefit."creditCardId") IS NOT NULL
+          AND (card."id" IS NULL OR card."userId" <> status."userId"))
+      )
+  ) THEN
+    RAISE EXCEPTION 'Cannot migrate not-usable status with cross-owner or missing custom benefit owner';
+  END IF;
+END $$;
+
 -- Existing preferences win only on identity; the requested migration adopts
 -- IGNORE for every target that has a legacy not-usable status.
 UPDATE "BenefitTrackingPreference" preference
@@ -114,6 +156,5 @@ WHERE NOT EXISTS (
 );
 
 UPDATE "BenefitStatus"
-SET "isNotUsable" = false,
-    "updatedAt" = CURRENT_TIMESTAMP
+SET "isNotUsable" = false
 WHERE "isNotUsable" = true;

--- a/prisma/migrations/20260831000000_migrate_not_usable_to_ignore/migration.sql
+++ b/prisma/migrations/20260831000000_migrate_not_usable_to_ignore/migration.sql
@@ -1,0 +1,119 @@
+-- The cycle-level isNotUsable flag is deprecated. Preserve the user's intent
+-- as a cycle-independent IGNORE preference, then clear the legacy flag so the
+-- same benefit is represented by one tracking model going forward.
+
+-- Refuse to guess if a legacy row does not carry a valid target identity. The
+-- migration is transactional, so this keeps the source flag intact for an
+-- operator to repair before retrying rather than silently dropping intent.
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM "BenefitStatus"
+    WHERE "isNotUsable" = true
+      AND NOT (
+        ("predefinedBenefitId" IS NOT NULL AND "creditCardId" IS NOT NULL)
+        OR ("predefinedBenefitId" IS NULL AND "benefitId" IS NOT NULL)
+      )
+  ) THEN
+    RAISE EXCEPTION 'Cannot migrate not-usable status with no valid tracking target';
+  END IF;
+END $$;
+
+-- Existing preferences win only on identity; the requested migration adopts
+-- IGNORE for every target that has a legacy not-usable status.
+UPDATE "BenefitTrackingPreference" preference
+SET "mode" = 'IGNORE'::"BenefitTrackingMode",
+    "updatedAt" = CURRENT_TIMESTAMP
+WHERE EXISTS (
+  SELECT 1
+  FROM "BenefitStatus" status
+  WHERE status."isNotUsable" = true
+    AND status."userId" = preference."userId"
+    AND (
+      (
+        status."predefinedBenefitId" IS NOT NULL
+        AND status."creditCardId" IS NOT NULL
+        AND preference."creditCardId" = status."creditCardId"
+        AND preference."predefinedBenefitId" = status."predefinedBenefitId"
+        AND preference."benefitId" IS NULL
+      )
+      OR (
+        status."predefinedBenefitId" IS NULL
+        AND status."benefitId" IS NOT NULL
+        AND preference."creditCardId" IS NULL
+        AND preference."predefinedBenefitId" IS NULL
+        AND preference."benefitId" = status."benefitId"
+      )
+    )
+);
+
+-- Standard benefits are keyed by physical card plus global benefit. DISTINCT
+-- ON prevents multiple historical cycles from violating the preference key.
+INSERT INTO "BenefitTrackingPreference" (
+  "id", "userId", "creditCardId", "predefinedBenefitId", "benefitId",
+  "mode", "createdAt", "updatedAt"
+)
+SELECT
+  md5('legacy-ignore:standard:' || status."userId" || ':' || status."creditCardId" || ':' || status."predefinedBenefitId"),
+  status."userId",
+  status."creditCardId",
+  status."predefinedBenefitId",
+  NULL,
+  'IGNORE'::"BenefitTrackingMode",
+  CURRENT_TIMESTAMP,
+  CURRENT_TIMESTAMP
+FROM (
+  SELECT DISTINCT ON ("userId", "creditCardId", "predefinedBenefitId")
+    "userId", "creditCardId", "predefinedBenefitId"
+  FROM "BenefitStatus"
+  WHERE "isNotUsable" = true
+    AND "creditCardId" IS NOT NULL
+    AND "predefinedBenefitId" IS NOT NULL
+  ORDER BY "userId", "creditCardId", "predefinedBenefitId", "id"
+) status
+WHERE NOT EXISTS (
+  SELECT 1
+  FROM "BenefitTrackingPreference" preference
+  WHERE preference."userId" = status."userId"
+    AND preference."creditCardId" = status."creditCardId"
+    AND preference."predefinedBenefitId" = status."predefinedBenefitId"
+    AND preference."benefitId" IS NULL
+);
+
+-- Custom/legacy benefits are keyed by their owned Benefit id.
+INSERT INTO "BenefitTrackingPreference" (
+  "id", "userId", "creditCardId", "predefinedBenefitId", "benefitId",
+  "mode", "createdAt", "updatedAt"
+)
+SELECT
+  md5('legacy-ignore:custom:' || status."userId" || ':' || status."benefitId"),
+  status."userId",
+  NULL,
+  NULL,
+  status."benefitId",
+  'IGNORE'::"BenefitTrackingMode",
+  CURRENT_TIMESTAMP,
+  CURRENT_TIMESTAMP
+FROM (
+  SELECT DISTINCT ON ("userId", "benefitId")
+    "userId", "benefitId"
+  FROM "BenefitStatus"
+  WHERE "isNotUsable" = true
+    AND "predefinedBenefitId" IS NULL
+    AND "benefitId" IS NOT NULL
+  ORDER BY "userId", "benefitId", "id"
+) status
+WHERE NOT EXISTS (
+  SELECT 1
+  FROM "BenefitTrackingPreference" preference
+  WHERE preference."userId" = status."userId"
+    AND preference."benefitId" = status."benefitId"
+    AND preference."creditCardId" IS NULL
+    AND preference."predefinedBenefitId" IS NULL
+);
+
+UPDATE "BenefitStatus"
+SET "isNotUsable" = false,
+    "updatedAt" = CURRENT_TIMESTAMP
+WHERE "isNotUsable" = true;

--- a/src/app/benefits/__tests__/tracking-mode-actions.test.ts
+++ b/src/app/benefits/__tests__/tracking-mode-actions.test.ts
@@ -245,6 +245,42 @@ describe('setBenefitTrackingModeAction', () => {
     expect(args.data.isCompleted).toBe(true);
   });
 
+  it('adopts IGNORE for a legacy not-usable row and clears the flag', async () => {
+    mockFindStatus.mockResolvedValue(standardStatus({ isNotUsable: true }));
+
+    await setBenefitTrackingModeAction(
+      form({ benefitStatusId: 'status-1', trackingMode: 'IGNORE' })
+    );
+
+    expect(preference.create).toHaveBeenCalledWith({
+      data: {
+        userId: 'user-1',
+        creditCardId: 'card-1',
+        predefinedBenefitId: 'pb-1',
+        benefitId: null,
+        mode: 'IGNORE',
+      },
+    });
+    expect(statusUpdateMany).toHaveBeenCalledWith({
+      where: { ...OPEN_CYCLE_STANDARD_WHERE, isNotUsable: true },
+      data: { isNotUsable: false },
+    });
+  });
+
+  it('clears the legacy flag when restoring TRACK on an open row', async () => {
+    mockFindStatus.mockResolvedValue(standardStatus({ isNotUsable: true }));
+
+    await setBenefitTrackingModeAction(
+      form({ benefitStatusId: 'status-1', trackingMode: 'TRACK' })
+    );
+
+    expect(preference.create).not.toHaveBeenCalled();
+    expect(statusUpdateMany).toHaveBeenCalledWith({
+      where: { ...OPEN_CYCLE_STANDARD_WHERE, isNotUsable: true },
+      data: { isNotUsable: false },
+    });
+  });
+
   it('claims zero rather than inventing value when the benefit has no maximum', async () => {
     mockFindStatus.mockResolvedValue(standardStatus({ benefit: { maxAmount: null, category: 'Travel' } }));
 

--- a/src/app/benefits/actions.ts
+++ b/src/app/benefits/actions.ts
@@ -380,6 +380,11 @@ export async function updateUsedAmountAction(formData: FormData) {
   }
 }
 
+/**
+ * @deprecated The dashboard no longer exposes this cycle-level mutation. Keep
+ * the server action for compatibility with legacy callers and persisted rows;
+ * existing not-usable statuses remain readable in the dashboard.
+ */
 export async function markBenefitAsNotUsableAction(formData: FormData) {
   const session = await getServerSession(authOptions);
   if (!session?.user?.id) {

--- a/src/app/benefits/actions.ts
+++ b/src/app/benefits/actions.ts
@@ -891,6 +891,15 @@ export async function setBenefitTrackingModeAction(formData: FormData) {
             isNotUsable: false,
           },
         });
+      } else if (status.isNotUsable) {
+        // Legacy rows may still carry the deprecated cycle-level flag until the
+        // data migration runs. Any explicit tracking choice adopts the new
+        // model for the open cycle and clears that flag so restoring TRACK does
+        // not make the row disappear from the dashboard on revalidation.
+        await transaction.benefitStatus.updateMany({
+          where: { ...openCycleWhere, isNotUsable: true },
+          data: { isNotUsable: false },
+        });
       }
 
       // Leaving AUTO_CLAIM reopens only claims this feature made. Rows the user

--- a/src/app/benefits/actions.ts
+++ b/src/app/benefits/actions.ts
@@ -927,9 +927,10 @@ export async function setBenefitTrackingModeAction(formData: FormData) {
  * Clears one tracking preference from the settings screen, returning the
  * benefit to the normal per-cycle workflow.
  *
- * This is the only way back for an IGNORE'd benefit, which by definition no
- * longer appears on the dashboard. A cycle that was auto-claimed on the user's
- * behalf is reopened so the benefit does not sit there falsely marked claimed.
+ * The settings screen is one restoration path for an IGNORE'd benefit; the
+ * dashboard's Ignored tab offers the same tracking-mode choice inline. A cycle
+ * that was auto-claimed on the user's behalf is reopened so the benefit does
+ * not sit there falsely marked claimed.
  */
 export async function resetBenefitTrackingPreferenceAction(formData: FormData) {
   const session = await getServerSession(authOptions);

--- a/src/components/BenefitCardClient.tsx
+++ b/src/components/BenefitCardClient.tsx
@@ -44,9 +44,11 @@ interface BenefitCardClientProps {
   onPartialCompletionChange?: (statusId: string, newUsedAmount: number, isNowComplete: boolean) => void;
   onTrackingModeChange?: (statusId: string, previousMode: BenefitTrackingMode, mode: BenefitTrackingMode) => void;
   isScheduled?: boolean;
+  /** Render a read-only card from the dashboard's Ignored tab. */
+  isIgnoredView?: boolean;
 }
 
-export default function BenefitCardClient({ status, onStatusChange, onDelete, onPartialCompletionChange, onTrackingModeChange, isScheduled = false }: BenefitCardClientProps) {
+export default function BenefitCardClient({ status, onStatusChange, onDelete, onPartialCompletionChange, onTrackingModeChange, isScheduled = false, isIgnoredView = false }: BenefitCardClientProps) {
   const [isPending, startTransition] = useTransition();
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
   const [showPartialModal, setShowPartialModal] = useState(false);
@@ -185,7 +187,7 @@ export default function BenefitCardClient({ status, onStatusChange, onDelete, on
   const isCompleted = status.isCompleted;
   const isCustomBenefit = status.isCustomBenefit;
   const hasPartialProgress = usedAmount > 0 && !isCompleted;
-  const statusLabel = isScheduled ? 'Scheduled' : isCompleted ? 'Claimed' : hasPartialProgress ? 'Partially used' : 'Open';
+  const statusLabel = isIgnoredView ? 'Ignored' : isScheduled ? 'Scheduled' : isCompleted ? 'Claimed' : hasPartialProgress ? 'Partially used' : 'Open';
 
   const card = status.benefit.creditCard;
   const cardIdentityDetails = card
@@ -377,7 +379,7 @@ export default function BenefitCardClient({ status, onStatusChange, onDelete, on
           <div className="sm:pl-11">
             <div className="flex flex-col sm:flex-row gap-2">
               {/* Completion buttons - hide for scheduled benefits */}
-              {!isScheduled && trackingMode !== 'AUTO_CLAIM' && (
+              {!isIgnoredView && !isScheduled && trackingMode !== 'AUTO_CLAIM' && (
                 <>
                   {isCompleted ? (
                     // For completed benefits, show "Mark Pending" to undo

--- a/src/components/BenefitCardClient.tsx
+++ b/src/components/BenefitCardClient.tsx
@@ -5,7 +5,6 @@ import Link from 'next/link';
 import { formatDate } from '@/lib/dateUtils';
 import {
   toggleBenefitStatusAction,
-  markBenefitAsNotUsableAction,
   deleteCustomBenefitAction,
   addPartialCompletionAction,
   markFullCompletionAction,
@@ -41,13 +40,12 @@ const TRACKING_MODE_OPTIONS: ReadonlyArray<{
 interface BenefitCardClientProps {
   status: DisplayBenefitStatus;
   onStatusChange?: (statusId: string, newIsCompleted: boolean, newUsedAmount?: number) => void;
-  onNotUsableChange?: (statusId: string, newIsNotUsable: boolean) => void;
   onDelete?: (benefitId: string) => void;
   onPartialCompletionChange?: (statusId: string, newUsedAmount: number, isNowComplete: boolean) => void;
   isScheduled?: boolean;
 }
 
-export default function BenefitCardClient({ status, onStatusChange, onNotUsableChange, onDelete, onPartialCompletionChange, isScheduled = false }: BenefitCardClientProps) {
+export default function BenefitCardClient({ status, onStatusChange, onDelete, onPartialCompletionChange, isScheduled = false }: BenefitCardClientProps) {
   const [isPending, startTransition] = useTransition();
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
   const [showPartialModal, setShowPartialModal] = useState(false);
@@ -160,24 +158,6 @@ export default function BenefitCardClient({ status, onStatusChange, onNotUsableC
       } catch (error) {
         console.error('Failed to add partial completion:', error);
         setActionError(error instanceof Error ? error.message : 'Failed to add used amount.');
-      }
-    });
-  };
-
-  const handleNotUsableSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
-    event.preventDefault();
-    const formData = new FormData(event.currentTarget);
-    const newIsNotUsable = !status.isNotUsable;
-
-    startTransition(async () => {
-      try {
-        setActionError(null);
-        await markBenefitAsNotUsableAction(formData);
-        // Call the callback to update parent state
-        onNotUsableChange?.(status.id, newIsNotUsable);
-      } catch (error) {
-        console.error('Failed to mark benefit as not usable:', error);
-        setActionError(error instanceof Error ? error.message : 'Failed to update benefit status.');
       }
     });
   };
@@ -482,52 +462,8 @@ export default function BenefitCardClient({ status, onStatusChange, onNotUsableC
                 </>
               )}
 
-              {/* Cycle-level exception: unlike the standing IGNORE preference,
-                  this only marks the current benefit cycle as unusable. */}
-              {!isCompleted && !isScheduled && (
-                <form onSubmit={handleNotUsableSubmit}>
-                  <input type="hidden" name="benefitStatusId" value={status.id} />
-                  <input type="hidden" name="isNotUsable" value={status.isNotUsable.toString()} />
-                  <button
-                    type="submit"
-                    disabled={isPending}
-                    title="Applies to this cycle only. Use the tracking menu to ignore this benefit in every cycle."
-                    className={`w-full sm:w-auto relative px-4 py-2 rounded-lg text-sm font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-offset-2 ${
-                      isNotUsable
-                        ? 'border border-border bg-card text-foreground hover:bg-accent focus:ring-ring'
-                        : 'border border-border bg-card text-foreground hover:bg-accent focus:ring-ring'
-                    } ${isPending ? 'opacity-50 cursor-not-allowed' : ''}`}
-                  >
-                    {isPending ? (
-                      <div className="flex items-center justify-center">
-                        <svg className="animate-spin -ml-1 mr-2 h-4 w-4 text-white" fill="none" viewBox="0 0 24 24">
-                          <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle>
-                          <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
-                        </svg>
-                        Updating...
-                      </div>
-                    ) : (
-                      <div className="flex items-center justify-center">
-                        {isNotUsable ? (
-                          <>
-                            <svg className="h-4 w-4 mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
-                            </svg>
-                            Mark usable this cycle
-                          </>
-                        ) : (
-                          <>
-                            <svg className="h-4 w-4 mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M18.364 18.364A9 9 0 005.636 5.636m12.728 12.728L5.636 5.636m12.728 12.728L5.636 5.636" />
-                            </svg>
-                            Not usable this cycle
-                          </>
-                        )}
-                      </div>
-                    )}
-                  </button>
-                </form>
-              )}
+              {/* Legacy cycle-level not-usable statuses remain visible for
+                  history, but this deprecated mutation is no longer exposed. */}
 
               {/* Cycle-independent tracking choice for benefits the user does
                   not want to confirm again every cycle. Available on scheduled

--- a/src/components/BenefitCardClient.tsx
+++ b/src/components/BenefitCardClient.tsx
@@ -491,7 +491,7 @@ export default function BenefitCardClient({ status, onStatusChange, onDelete, on
               </button>
 
               {/* Delete button - only show for custom benefits */}
-              {isCustomBenefit && (
+              {isCustomBenefit && !isIgnoredView && (
                 <button
                   type="button"
                   onClick={() => setShowDeleteConfirm(true)}

--- a/src/components/BenefitCardClient.tsx
+++ b/src/components/BenefitCardClient.tsx
@@ -184,9 +184,8 @@ export default function BenefitCardClient({ status, onStatusChange, onDelete, on
 
   const isCompleted = status.isCompleted;
   const isCustomBenefit = status.isCustomBenefit;
-  const isNotUsable = status.isNotUsable;
   const hasPartialProgress = usedAmount > 0 && !isCompleted;
-  const statusLabel = isScheduled ? 'Scheduled' : isCompleted ? 'Claimed' : isNotUsable ? 'Not usable' : hasPartialProgress ? 'Partially used' : 'Open';
+  const statusLabel = isScheduled ? 'Scheduled' : isCompleted ? 'Claimed' : hasPartialProgress ? 'Partially used' : 'Open';
 
   const card = status.benefit.creditCard;
   const cardIdentityDetails = card
@@ -202,12 +201,10 @@ export default function BenefitCardClient({ status, onStatusChange, onDelete, on
         ? 'bg-card border-border'
         : isCompleted
           ? 'bg-card border-emerald-200 dark:border-emerald-900/70'
-          : isNotUsable
-            ? 'bg-muted/45 border-border'
-            : 'bg-card border-border hover:bg-accent/35'
+          : 'bg-card border-border hover:bg-accent/35'
     }`}>
             <div className={`absolute top-0 left-0 w-1 h-full ${
-        isScheduled ? 'bg-muted-foreground' : isCompleted ? 'bg-emerald-500' : isNotUsable ? 'bg-muted-foreground' : 'bg-amber-500'
+        isScheduled ? 'bg-muted-foreground' : isCompleted ? 'bg-emerald-500' : 'bg-amber-500'
       }`} />
 
       <div className="p-4 sm:p-5">
@@ -218,9 +215,7 @@ export default function BenefitCardClient({ status, onStatusChange, onDelete, on
                 ? 'bg-muted'
                 : isCompleted
                   ? 'bg-emerald-50 dark:bg-emerald-950/30'
-                  : isNotUsable
-                    ? 'bg-muted'
-                    : 'bg-muted'
+                  : 'bg-muted'
             }`}>
               {isScheduled ? (
                 <svg className="h-5 w-5 text-muted-foreground" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -229,10 +224,6 @@ export default function BenefitCardClient({ status, onStatusChange, onDelete, on
               ) : isCompleted ? (
                 <svg className="h-5 w-5 text-emerald-600 dark:text-emerald-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
-                </svg>
-              ) : isNotUsable ? (
-                <svg className="h-5 w-5 text-muted-foreground" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M18.364 18.364A9 9 0 005.636 5.636m12.728 12.728L5.636 5.636m12.728 12.728L5.636 5.636" />
                 </svg>
               ) : (
                 <svg className="h-5 w-5 text-muted-foreground" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -247,11 +238,9 @@ export default function BenefitCardClient({ status, onStatusChange, onDelete, on
                     ? 'bg-muted text-muted-foreground ring-1 ring-border'
                     : isCompleted
                       ? 'bg-emerald-50 text-emerald-700 ring-1 ring-emerald-200 dark:bg-emerald-900/30 dark:text-emerald-200 dark:ring-emerald-800'
-                      : isNotUsable
-                        ? 'bg-gray-100 text-gray-600 ring-1 ring-gray-200 dark:bg-gray-700 dark:text-gray-300 dark:ring-gray-600'
-                        : hasPartialProgress
-                          ? 'bg-amber-50 text-amber-700 ring-1 ring-amber-200 dark:bg-amber-900/30 dark:text-amber-200 dark:ring-amber-800'
-                          : 'bg-amber-50 text-amber-800 ring-1 ring-amber-200 dark:bg-amber-950/30 dark:text-amber-200 dark:ring-amber-900/60'
+                      : hasPartialProgress
+                        ? 'bg-amber-50 text-amber-700 ring-1 ring-amber-200 dark:bg-amber-900/30 dark:text-amber-200 dark:ring-amber-800'
+                        : 'bg-amber-50 text-amber-800 ring-1 ring-amber-200 dark:bg-amber-950/30 dark:text-amber-200 dark:ring-amber-900/60'
                 }`}>
                   {statusLabel}
                 </span>
@@ -272,11 +261,9 @@ export default function BenefitCardClient({ status, onStatusChange, onDelete, on
                   <p className={`text-lg sm:text-xl font-semibold tabular-nums ${
                     isCompleted
                       ? 'text-emerald-600 dark:text-emerald-400'
-                      : isNotUsable
-                        ? 'text-muted-foreground'
-                        : hasPartialProgress
-                          ? 'text-amber-600 dark:text-amber-400'
-                          : 'text-muted-foreground'
+                      : hasPartialProgress
+                        ? 'text-amber-600 dark:text-amber-400'
+                        : 'text-muted-foreground'
                   }`}>
                     {hasPartialProgress ? (
                       <span>
@@ -390,7 +377,7 @@ export default function BenefitCardClient({ status, onStatusChange, onDelete, on
           <div className="sm:pl-11">
             <div className="flex flex-col sm:flex-row gap-2">
               {/* Completion buttons - hide for scheduled benefits */}
-              {!isScheduled && !isNotUsable && trackingMode !== 'AUTO_CLAIM' && (
+              {!isScheduled && trackingMode !== 'AUTO_CLAIM' && (
                 <>
                   {isCompleted ? (
                     // For completed benefits, show "Mark Pending" to undo
@@ -465,9 +452,6 @@ export default function BenefitCardClient({ status, onStatusChange, onDelete, on
                   )}
                 </>
               )}
-
-              {/* Legacy cycle-level not-usable statuses remain visible for
-                  history, but this deprecated mutation is no longer exposed. */}
 
               {/* Cycle-independent tracking choice for benefits the user does
                   not want to confirm again every cycle. Available on scheduled

--- a/src/components/BenefitCardClient.tsx
+++ b/src/components/BenefitCardClient.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useId, useState, useTransition } from 'react';
+import React, { useEffect, useId, useState, useTransition } from 'react';
 import Link from 'next/link';
 import { formatDate } from '@/lib/dateUtils';
 import {
@@ -57,7 +57,16 @@ export default function BenefitCardClient({ status, onStatusChange, onNotUsableC
   const [showTrackingMenu, setShowTrackingMenu] = useState(false);
 
   const trackingPanelId = useId();
-  const trackingMode: BenefitTrackingMode = status.trackingMode ?? 'TRACK';
+  const [trackingMode, setTrackingMode] = useState<BenefitTrackingMode>(status.trackingMode ?? 'TRACK');
+  const trackingModeLabel = TRACKING_MODE_OPTIONS.find((option) => option.mode === trackingMode)?.label ?? 'Track every cycle';
+
+  // The tracking action revalidates the server data, but this card can remain
+  // mounted in the dashboard's local mirror. Keep the control responsive until
+  // the parent receives fresh props, while still treating the server action as
+  // the source of truth (only update after it succeeds).
+  useEffect(() => {
+    setTrackingMode(status.trackingMode ?? 'TRACK');
+  }, [status.trackingMode]);
 
   const handleTrackingModeChange = (mode: BenefitTrackingMode) => {
     if (mode === trackingMode) {
@@ -72,6 +81,7 @@ export default function BenefitCardClient({ status, onStatusChange, onNotUsableC
       try {
         setActionError(null);
         await setBenefitTrackingModeAction(formData);
+        setTrackingMode(mode);
         setShowTrackingMenu(false);
       } catch (error) {
         console.error('Failed to set benefit tracking mode:', error);
@@ -472,7 +482,8 @@ export default function BenefitCardClient({ status, onStatusChange, onNotUsableC
                 </>
               )}
 
-              {/* Not Usable button - only show for upcoming benefits, not scheduled */}
+              {/* Cycle-level exception: unlike the standing IGNORE preference,
+                  this only marks the current benefit cycle as unusable. */}
               {!isCompleted && !isScheduled && (
                 <form onSubmit={handleNotUsableSubmit}>
                   <input type="hidden" name="benefitStatusId" value={status.id} />
@@ -480,6 +491,7 @@ export default function BenefitCardClient({ status, onStatusChange, onNotUsableC
                   <button
                     type="submit"
                     disabled={isPending}
+                    title="Applies to this cycle only. Use the tracking menu to ignore this benefit in every cycle."
                     className={`w-full sm:w-auto relative px-4 py-2 rounded-lg text-sm font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-offset-2 ${
                       isNotUsable
                         ? 'border border-border bg-card text-foreground hover:bg-accent focus:ring-ring'
@@ -501,14 +513,14 @@ export default function BenefitCardClient({ status, onStatusChange, onNotUsableC
                             <svg className="h-4 w-4 mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
                             </svg>
-                            Mark Usable
+                            Mark usable this cycle
                           </>
                         ) : (
                           <>
                             <svg className="h-4 w-4 mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M18.364 18.364A9 9 0 005.636 5.636m12.728 12.728L5.636 5.636m12.728 12.728L5.636 5.636" />
                             </svg>
-                            Not Usable
+                            Not usable this cycle
                           </>
                         )}
                       </div>
@@ -527,23 +539,21 @@ export default function BenefitCardClient({ status, onStatusChange, onNotUsableC
                 onClick={() => setShowTrackingMenu((open) => !open)}
                 aria-expanded={showTrackingMenu}
                 aria-controls={trackingPanelId}
+                aria-label={`Tracking mode: ${trackingModeLabel}. ${showTrackingMenu ? 'Close' : 'Choose'} tracking mode`}
                 className={`w-full sm:w-auto px-4 py-2 rounded-lg text-sm font-medium border transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 ${
                   showTrackingMenu || trackingMode !== 'TRACK'
-                    ? 'border-indigo-300 bg-accent text-foreground dark:border-indigo-700'
+                    ? 'border-indigo-400 bg-indigo-50 text-indigo-950 shadow-sm dark:border-indigo-600 dark:bg-indigo-950/40 dark:text-indigo-100'
                     : 'border-border bg-card text-foreground hover:bg-accent'
                 } ${isPending ? 'opacity-50 cursor-not-allowed' : ''}`}
               >
                 <div className="flex items-center justify-center">
-                  <svg className="h-4 w-4 mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <svg aria-hidden="true" className="h-4 w-4 mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" />
                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
                   </svg>
-                  {trackingMode === 'AUTO_CLAIM'
-                    ? 'Auto-claimed'
-                    : trackingMode === 'IGNORE'
-                      ? 'Ignored'
-                      : 'Tracking'}
+                  <span>Tracking: {trackingModeLabel}</span>
                   <svg
+                    aria-hidden="true"
                     className={`h-3 w-3 ml-1 transition-transform ${showTrackingMenu ? 'rotate-180' : ''}`}
                     fill="none"
                     stroke="currentColor"
@@ -595,17 +605,33 @@ export default function BenefitCardClient({ status, onStatusChange, onNotUsableC
                         onClick={() => handleTrackingModeChange(option.mode)}
                         className={`w-full rounded-md border px-3 py-2 text-left transition-colors focus:outline-none focus:ring-2 focus:ring-ring ${
                           isActive
-                            ? 'border-indigo-300 bg-accent dark:border-indigo-700'
+                            ? 'border-indigo-400 bg-indigo-50 shadow-sm dark:border-indigo-600 dark:bg-indigo-950/40'
                             : 'border-transparent hover:bg-accent'
                         } ${isPending ? 'opacity-50 cursor-not-allowed' : ''}`}
                       >
-                        <div className="flex items-center text-sm font-medium text-foreground">
+                        <div className="flex items-center justify-between gap-2 text-sm font-medium text-foreground">
+                          <span className="flex items-center">
+                            <span
+                              aria-hidden="true"
+                              className={`mr-2 flex h-4 w-4 items-center justify-center rounded-full border ${
+                                isActive
+                                  ? 'border-indigo-600 bg-indigo-600 text-white dark:border-indigo-400 dark:bg-indigo-400 dark:text-indigo-950'
+                                  : 'border-muted-foreground/50'
+                              }`}
+                            >
+                              {isActive && (
+                                <svg className="h-3 w-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+                                </svg>
+                              )}
+                            </span>
+                            {option.label}
+                          </span>
                           {isActive && (
-                            <svg className="h-4 w-4 mr-1 text-indigo-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
-                            </svg>
+                            <span className="text-xs font-semibold uppercase tracking-wide text-indigo-700 dark:text-indigo-300">
+                              Current
+                            </span>
                           )}
-                          {option.label}
                         </div>
                         <div className="mt-0.5 text-xs text-muted-foreground">{option.description}</div>
                       </button>

--- a/src/components/BenefitCardClient.tsx
+++ b/src/components/BenefitCardClient.tsx
@@ -42,10 +42,11 @@ interface BenefitCardClientProps {
   onStatusChange?: (statusId: string, newIsCompleted: boolean, newUsedAmount?: number) => void;
   onDelete?: (benefitId: string) => void;
   onPartialCompletionChange?: (statusId: string, newUsedAmount: number, isNowComplete: boolean) => void;
+  onTrackingModeChange?: (statusId: string, previousMode: BenefitTrackingMode, mode: BenefitTrackingMode) => void;
   isScheduled?: boolean;
 }
 
-export default function BenefitCardClient({ status, onStatusChange, onDelete, onPartialCompletionChange, isScheduled = false }: BenefitCardClientProps) {
+export default function BenefitCardClient({ status, onStatusChange, onDelete, onPartialCompletionChange, onTrackingModeChange, isScheduled = false }: BenefitCardClientProps) {
   const [isPending, startTransition] = useTransition();
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
   const [showPartialModal, setShowPartialModal] = useState(false);
@@ -71,6 +72,7 @@ export default function BenefitCardClient({ status, onStatusChange, onDelete, on
       setShowTrackingMenu(false);
       return;
     }
+    const previousMode = trackingMode;
     const formData = new FormData();
     formData.append('benefitStatusId', status.id);
     formData.append('trackingMode', mode);
@@ -81,6 +83,7 @@ export default function BenefitCardClient({ status, onStatusChange, onDelete, on
         await setBenefitTrackingModeAction(formData);
         setTrackingMode(mode);
         setShowTrackingMenu(false);
+        onTrackingModeChange?.(status.id, previousMode, mode);
       } catch (error) {
         console.error('Failed to set benefit tracking mode:', error);
         setActionError(error instanceof Error ? error.message : 'Failed to update tracking mode.');
@@ -184,6 +187,7 @@ export default function BenefitCardClient({ status, onStatusChange, onDelete, on
   const isNotUsable = status.isNotUsable;
   const hasPartialProgress = usedAmount > 0 && !isCompleted;
   const statusLabel = isScheduled ? 'Scheduled' : isCompleted ? 'Claimed' : isNotUsable ? 'Not usable' : hasPartialProgress ? 'Partially used' : 'Open';
+
   const card = status.benefit.creditCard;
   const cardIdentityDetails = card
     ? [
@@ -386,7 +390,7 @@ export default function BenefitCardClient({ status, onStatusChange, onDelete, on
           <div className="sm:pl-11">
             <div className="flex flex-col sm:flex-row gap-2">
               {/* Completion buttons - hide for scheduled benefits */}
-              {!isScheduled && !isNotUsable && (
+              {!isScheduled && !isNotUsable && trackingMode !== 'AUTO_CLAIM' && (
                 <>
                   {isCompleted ? (
                     // For completed benefits, show "Mark Pending" to undo

--- a/src/components/BenefitCardClient.tsx
+++ b/src/components/BenefitCardClient.tsx
@@ -33,7 +33,7 @@ const TRACKING_MODE_OPTIONS: ReadonlyArray<{
   {
     mode: 'IGNORE',
     label: 'Ignore this benefit',
-    description: 'Hides it everywhere and drops it from claimed value and ROI.',
+    description: 'Moves it to the Ignored tab and drops it from totals and ROI.',
   },
 ];
 

--- a/src/components/BenefitsDisplayClient.tsx
+++ b/src/components/BenefitsDisplayClient.tsx
@@ -15,6 +15,7 @@ import {
   type BenefitDashboardFrequency,
   type DisplayBenefitStatus,
 } from '@/lib/benefit-dashboard-client';
+import type { BenefitTrackingMode } from '@/lib/benefit-tracking-modes';
 
 interface BenefitsDisplayProps {
   upcomingBenefits: DisplayBenefitStatus[];
@@ -60,7 +61,7 @@ export default function BenefitsDisplayClient({
   const [localUpcomingBenefits, setLocalUpcomingBenefits] = useState(upcomingBenefits);
   const [localCompletedBenefits, setLocalCompletedBenefits] = useState(completedBenefits);
   const [localNotUsableBenefits, setLocalNotUsableBenefits] = useState(notUsableBenefits);
-  const [localScheduledBenefits] = useState(scheduledBenefits);
+  const [localScheduledBenefits, setLocalScheduledBenefits] = useState(scheduledBenefits);
   const [localTotalUnusedValue, setLocalTotalUnusedValue] = useState(totalUnusedValue);
   const [localTotalUsedValue, setLocalTotalUsedValue] = useState(totalUsedValue);
   const [localTotalNotUsableValue, setLocalTotalNotUsableValue] = useState(totalNotUsableValue);
@@ -193,6 +194,89 @@ export default function BenefitsDisplayClient({
         setLocalTotalNotUsableValue(prev => prev - maxAmount);
       }
     }
+  };
+
+  /**
+   * Mirror the server-side tracking transition immediately in the dashboard.
+   * AUTO_CLAIM claims the currently open row and moves it to Claimed; IGNORE
+   * removes the row from every visible tab and its corresponding totals.
+   */
+  const handleTrackingModeChange = (
+    statusId: string,
+    _previousMode: BenefitTrackingMode,
+    mode: BenefitTrackingMode,
+  ) => {
+    const upcoming = localUpcomingBenefits.find((benefit) => benefit.id === statusId);
+    const completed = localCompletedBenefits.find((benefit) => benefit.id === statusId);
+    const notUsable = localNotUsableBenefits.find((benefit) => benefit.id === statusId);
+    const scheduled = localScheduledBenefits.find((benefit) => benefit.id === statusId);
+    const status = upcoming ?? completed ?? notUsable ?? scheduled;
+    if (!status) return;
+
+    const maxAmount = Math.max(0, status.benefit.maxAmount ?? 0);
+    const usedAmount = Math.max(0, status.usedAmount ?? 0);
+    const claimedAmount = resolveBenefitClaimedValue(status);
+
+    if (mode === 'IGNORE') {
+      setLocalUpcomingBenefits((items) => items.filter((item) => item.id !== statusId));
+      setLocalCompletedBenefits((items) => items.filter((item) => item.id !== statusId));
+      setLocalNotUsableBenefits((items) => items.filter((item) => item.id !== statusId));
+      setLocalScheduledBenefits((items) => items.filter((item) => item.id !== statusId));
+
+      if (upcoming) {
+        setLocalTotalUnusedValue((value) => value - Math.max(0, maxAmount - usedAmount));
+        setLocalTotalUsedValue((value) => value - usedAmount);
+      } else if (completed) {
+        setLocalTotalUsedValue((value) => value - claimedAmount);
+      } else if (notUsable) {
+        setLocalTotalNotUsableValue((value) => value - maxAmount);
+      }
+      return;
+    }
+
+    // AUTO_CLAIM only changes the currently open cycle. Scheduled rows remain
+    // scheduled until their cycle opens and the server materializes the claim.
+    if (mode === 'AUTO_CLAIM' && upcoming && !status.isCompleted && !status.isNotUsable) {
+      const claimedStatus: DisplayBenefitStatus = {
+        ...status,
+        isCompleted: true,
+        isNotUsable: false,
+        completedAt: new Date(),
+        usedAmount: maxAmount,
+        trackingMode: mode,
+      };
+      setLocalUpcomingBenefits((items) => items.filter((item) => item.id !== statusId));
+      setLocalCompletedBenefits((items) => [...items, claimedStatus]);
+      setLocalTotalUnusedValue((value) => value - Math.max(0, maxAmount - usedAmount));
+      setLocalTotalUsedValue((value) => value + Math.max(0, maxAmount - usedAmount));
+      return;
+    }
+
+    // An ignored/not-usable open row can also be auto-claimed; account for
+    // that transition when the server clears isNotUsable.
+    if (mode === 'AUTO_CLAIM' && notUsable && !status.isCompleted) {
+      const claimedStatus: DisplayBenefitStatus = {
+        ...status,
+        isCompleted: true,
+        isNotUsable: false,
+        completedAt: new Date(),
+        usedAmount: maxAmount,
+        trackingMode: mode,
+      };
+      setLocalNotUsableBenefits((items) => items.filter((item) => item.id !== statusId));
+      setLocalCompletedBenefits((items) => [...items, claimedStatus]);
+      setLocalTotalNotUsableValue((value) => value - maxAmount);
+      setLocalTotalUsedValue((value) => value + maxAmount);
+      return;
+    }
+
+    // Keep the mode in the local row when no list transition is needed.
+    const updateMode = (items: DisplayBenefitStatus[]) =>
+      items.map((item) => item.id === statusId ? { ...item, trackingMode: mode } : item);
+    setLocalUpcomingBenefits(updateMode);
+    setLocalCompletedBenefits(updateMode);
+    setLocalNotUsableBenefits(updateMode);
+    setLocalScheduledBenefits(updateMode);
   };
 
 
@@ -361,6 +445,7 @@ export default function BenefitsDisplayClient({
             onStatusChange={handleStatusChange} 
             onDelete={handleDeleteBenefit}
             onPartialCompletionChange={handlePartialCompletionChange}
+            onTrackingModeChange={handleTrackingModeChange}
             isScheduled={true}
           />
         ))}
@@ -413,6 +498,7 @@ export default function BenefitsDisplayClient({
             onStatusChange={handleStatusChange}
             onDelete={handleDeleteBenefit}
             onPartialCompletionChange={handlePartialCompletionChange}
+            onTrackingModeChange={handleTrackingModeChange}
           />
         ))}
       </div>
@@ -464,6 +550,7 @@ export default function BenefitsDisplayClient({
             onStatusChange={handleStatusChange}
             onDelete={handleDeleteBenefit}
             onPartialCompletionChange={handlePartialCompletionChange}
+            onTrackingModeChange={handleTrackingModeChange}
           />
         ))}
       </div>

--- a/src/components/BenefitsDisplayClient.tsx
+++ b/src/components/BenefitsDisplayClient.tsx
@@ -231,19 +231,32 @@ export default function BenefitsDisplayClient({
       const restoredStatus = { ...ignored, trackingMode: mode };
       setLocalIgnoredBenefits((items) => items.filter((item) => item.id !== statusId));
       let restoredToTrackedTab = false;
-      if (restoredStatus.isCompleted) {
+      const cycleStart = new Date(restoredStatus.cycleStartDate).getTime();
+      const cycleEnd = new Date(restoredStatus.cycleEndDate).getTime();
+      const cycleIsOpen = cycleStart <= Date.now() && cycleEnd >= Date.now();
+      if (mode === 'AUTO_CLAIM' && !restoredStatus.isCompleted && cycleIsOpen) {
+        setLocalCompletedBenefits((items) => [...items, {
+          ...restoredStatus,
+          isCompleted: true,
+          completedAt: new Date(),
+          usedAmount: maxAmount,
+        }]);
+        restoredToTrackedTab = true;
+        setLocalTotalUnusedValue((value) => value - Math.max(0, maxAmount - usedAmount));
+        setLocalTotalUsedValue((value) => value + Math.max(0, maxAmount - usedAmount));
+      } else if (restoredStatus.isCompleted) {
         setLocalCompletedBenefits((items) => [...items, restoredStatus]);
         restoredToTrackedTab = true;
-      } else if (new Date(restoredStatus.cycleStartDate).getTime() > Date.now()) {
+      } else if (cycleStart > Date.now()) {
         setLocalScheduledBenefits((items) => [...items, restoredStatus]);
         // Scheduled benefits do not contribute to current totals yet.
-      } else if (new Date(restoredStatus.cycleEndDate).getTime() >= Date.now()) {
+      } else if (cycleEnd >= Date.now()) {
         setLocalUpcomingBenefits((items) => [...items, restoredStatus]);
         restoredToTrackedTab = true;
       }
       if (restoredStatus.isCompleted) {
         setLocalTotalUsedValue((value) => value + claimedAmount);
-      } else if (restoredToTrackedTab) {
+      } else if (restoredToTrackedTab && mode !== 'AUTO_CLAIM') {
         setLocalTotalUnusedValue((value) => value + Math.max(0, maxAmount - usedAmount));
         setLocalTotalUsedValue((value) => value + usedAmount);
       }

--- a/src/components/BenefitsDisplayClient.tsx
+++ b/src/components/BenefitsDisplayClient.tsx
@@ -20,11 +20,9 @@ import type { BenefitTrackingMode } from '@/lib/benefit-tracking-modes';
 interface BenefitsDisplayProps {
   upcomingBenefits: DisplayBenefitStatus[];
   completedBenefits: DisplayBenefitStatus[];
-  notUsableBenefits: DisplayBenefitStatus[];
   scheduledBenefits: DisplayBenefitStatus[];
   totalUnusedValue: number;
   totalUsedValue: number;
-  totalNotUsableValue: number;
   totalAnnualFees: number;
   cardLevelRoi?: CardLevelRoi[];
   cardCount?: number;
@@ -35,11 +33,9 @@ interface BenefitsDisplayProps {
 export default function BenefitsDisplayClient({
   upcomingBenefits,
   completedBenefits,
-  notUsableBenefits,
   scheduledBenefits,
   totalUnusedValue,
   totalUsedValue,
-  totalNotUsableValue,
   totalAnnualFees,
   cardLevelRoi = [],
   cardCount = 0,
@@ -60,11 +56,9 @@ export default function BenefitsDisplayClient({
   const [sortMode, setSortMode] = useState<'expires' | 'value' | 'card'>('expires');
   const [localUpcomingBenefits, setLocalUpcomingBenefits] = useState(upcomingBenefits);
   const [localCompletedBenefits, setLocalCompletedBenefits] = useState(completedBenefits);
-  const [localNotUsableBenefits, setLocalNotUsableBenefits] = useState(notUsableBenefits);
   const [localScheduledBenefits, setLocalScheduledBenefits] = useState(scheduledBenefits);
   const [localTotalUnusedValue, setLocalTotalUnusedValue] = useState(totalUnusedValue);
   const [localTotalUsedValue, setLocalTotalUsedValue] = useState(totalUsedValue);
-  const [localTotalNotUsableValue, setLocalTotalNotUsableValue] = useState(totalNotUsableValue);
 
   // Recompute per-card claimed value from local benefits so ROI breakdown updates when user marks complete
   const cardLevelRoiLive = useMemo(() => {
@@ -173,7 +167,7 @@ export default function BenefitsDisplayClient({
       list.filter(b => b.benefit.id !== benefitId);
     
     // Find the benefit to get its value for updating totals
-    const allBenefits = [...localUpcomingBenefits, ...localCompletedBenefits, ...localNotUsableBenefits];
+    const allBenefits = [...localUpcomingBenefits, ...localCompletedBenefits];
     const deletedBenefit = allBenefits.find(b => b.benefit.id === benefitId);
     
     if (deletedBenefit) {
@@ -189,9 +183,6 @@ export default function BenefitsDisplayClient({
         setLocalCompletedBenefits(findAndRemove);
         // For completed: remove the used amount
         setLocalTotalUsedValue(prev => prev - usedAmount);
-      } else if (localNotUsableBenefits.some(b => b.benefit.id === benefitId)) {
-        setLocalNotUsableBenefits(findAndRemove);
-        setLocalTotalNotUsableValue(prev => prev - maxAmount);
       }
     }
   };
@@ -208,9 +199,8 @@ export default function BenefitsDisplayClient({
   ) => {
     const upcoming = localUpcomingBenefits.find((benefit) => benefit.id === statusId);
     const completed = localCompletedBenefits.find((benefit) => benefit.id === statusId);
-    const notUsable = localNotUsableBenefits.find((benefit) => benefit.id === statusId);
     const scheduled = localScheduledBenefits.find((benefit) => benefit.id === statusId);
-    const status = upcoming ?? completed ?? notUsable ?? scheduled;
+    const status = upcoming ?? completed ?? scheduled;
     if (!status) return;
 
     const maxAmount = Math.max(0, status.benefit.maxAmount ?? 0);
@@ -220,7 +210,6 @@ export default function BenefitsDisplayClient({
     if (mode === 'IGNORE') {
       setLocalUpcomingBenefits((items) => items.filter((item) => item.id !== statusId));
       setLocalCompletedBenefits((items) => items.filter((item) => item.id !== statusId));
-      setLocalNotUsableBenefits((items) => items.filter((item) => item.id !== statusId));
       setLocalScheduledBenefits((items) => items.filter((item) => item.id !== statusId));
 
       if (upcoming) {
@@ -228,19 +217,16 @@ export default function BenefitsDisplayClient({
         setLocalTotalUsedValue((value) => value - usedAmount);
       } else if (completed) {
         setLocalTotalUsedValue((value) => value - claimedAmount);
-      } else if (notUsable) {
-        setLocalTotalNotUsableValue((value) => value - maxAmount);
       }
       return;
     }
 
     // AUTO_CLAIM only changes the currently open cycle. Scheduled rows remain
     // scheduled until their cycle opens and the server materializes the claim.
-    if (mode === 'AUTO_CLAIM' && upcoming && !status.isCompleted && !status.isNotUsable) {
+    if (mode === 'AUTO_CLAIM' && upcoming && !status.isCompleted) {
       const claimedStatus: DisplayBenefitStatus = {
         ...status,
         isCompleted: true,
-        isNotUsable: false,
         completedAt: new Date(),
         usedAmount: maxAmount,
         trackingMode: mode,
@@ -252,30 +238,11 @@ export default function BenefitsDisplayClient({
       return;
     }
 
-    // An ignored/not-usable open row can also be auto-claimed; account for
-    // that transition when the server clears isNotUsable.
-    if (mode === 'AUTO_CLAIM' && notUsable && !status.isCompleted) {
-      const claimedStatus: DisplayBenefitStatus = {
-        ...status,
-        isCompleted: true,
-        isNotUsable: false,
-        completedAt: new Date(),
-        usedAmount: maxAmount,
-        trackingMode: mode,
-      };
-      setLocalNotUsableBenefits((items) => items.filter((item) => item.id !== statusId));
-      setLocalCompletedBenefits((items) => [...items, claimedStatus]);
-      setLocalTotalNotUsableValue((value) => value - maxAmount);
-      setLocalTotalUsedValue((value) => value + maxAmount);
-      return;
-    }
-
     // Keep the mode in the local row when no list transition is needed.
     const updateMode = (items: DisplayBenefitStatus[]) =>
       items.map((item) => item.id === statusId ? { ...item, trackingMode: mode } : item);
     setLocalUpcomingBenefits(updateMode);
     setLocalCompletedBenefits(updateMode);
-    setLocalNotUsableBenefits(updateMode);
     setLocalScheduledBenefits(updateMode);
   };
 
@@ -327,14 +294,12 @@ export default function BenefitsDisplayClient({
         return localUpcomingBenefits;
       case 'completed':
         return localCompletedBenefits;
-      case 'not-usable':
-        return localNotUsableBenefits;
       case 'scheduled':
         return localScheduledBenefits;
       default:
         return [];
     }
-  }, [activeTab, localUpcomingBenefits, localCompletedBenefits, localNotUsableBenefits, localScheduledBenefits]);
+  }, [activeTab, localUpcomingBenefits, localCompletedBenefits, localScheduledBenefits]);
 
   const uniqueCategories = useMemo(
     () => Array.from(new Set(allBenefitsForTab.map((b) => b.benefit.category))).sort(),
@@ -476,11 +441,6 @@ export default function BenefitsDisplayClient({
           title: 'No completed benefits yet',
           description: 'Mark benefits as complete when you use them to track your ROI.',
         },
-        'not-usable': {
-          icon: 'x-circle' as const,
-          title: 'No not usable benefits',
-          description: 'Benefits marked as not usable will appear here.',
-        },
       };
       const props = emptyStateProps[activeTab as keyof typeof emptyStateProps] || emptyStateProps.upcoming;
       return <EmptyState {...props} />;
@@ -527,11 +487,6 @@ export default function BenefitsDisplayClient({
           icon: 'check' as const,
           title: 'No Benefits Available',
           description: 'No completed benefits yet. Start using your credit card benefits!',
-        },
-        'not-usable': {
-          icon: 'x-circle' as const,
-          title: 'No Benefits Available',
-          description: 'No unusable benefits found.',
         },
       };
       const props = emptyStateProps[activeTab as keyof typeof emptyStateProps] || emptyStateProps.upcoming;
@@ -644,7 +599,6 @@ export default function BenefitsDisplayClient({
         {[
           ['Upcoming Benefits', `$${localTotalUnusedValue.toFixed(2)}`, 'Still available this cycle'],
           ['Claimed Benefits', `$${localTotalUsedValue.toFixed(2)}`, 'Recorded as used'],
-          ['Not Usable', `$${localTotalNotUsableValue.toFixed(2)}`, 'Excluded from ROI'],
           ['Annual Fee ROI', `$${(localTotalUsedValue - totalAnnualFees).toFixed(2)}`, `$${localTotalUsedValue.toFixed(2)} claimed vs $${totalAnnualFees.toFixed(2)} fees`],
         ].map(([label, value, detail]) => (
           <div key={label} className="rounded-xl border border-border bg-card p-4 shadow-sm shadow-black/[0.03]">
@@ -726,17 +680,6 @@ export default function BenefitsDisplayClient({
           >
             <span className="hidden sm:inline">Claimed ({localCompletedBenefits.length})</span>
             <span className="sm:hidden">Claimed ({localCompletedBenefits.length})</span>
-          </button>
-          <button
-            onClick={() => setActiveTab('not-usable')}
-            className={`flex-shrink-0 py-4 px-1 border-b-2 font-medium text-sm
-              ${activeTab === 'not-usable'
-                ? 'border-foreground text-foreground'
-                : 'border-transparent text-muted-foreground hover:border-border hover:text-foreground'}
-            `}
-          >
-            <span className="hidden sm:inline">Not Usable ({localNotUsableBenefits.length})</span>
-            <span className="sm:hidden">Not Usable ({localNotUsableBenefits.length})</span>
           </button>
           {localScheduledBenefits.length > 0 && (
             <button
@@ -888,11 +831,6 @@ export default function BenefitsDisplayClient({
         {activeTab === 'completed' && (
           <section>
             {viewMode === 'category' ? renderCategoryView(sortBenefits(applyPowerUserFilters(filterBenefits(localCompletedBenefits)))) : renderCardView(sortBenefits(applyPowerUserFilters(filterBenefits(localCompletedBenefits))))}
-          </section>
-        )}
-        {activeTab === 'not-usable' && (
-          <section>
-            {viewMode === 'category' ? renderCategoryView(sortBenefits(applyPowerUserFilters(filterBenefits(localNotUsableBenefits)))) : renderCardView(sortBenefits(applyPowerUserFilters(filterBenefits(localNotUsableBenefits))))}
           </section>
         )}
         {activeTab === 'scheduled' && (

--- a/src/components/BenefitsDisplayClient.tsx
+++ b/src/components/BenefitsDisplayClient.tsx
@@ -166,36 +166,6 @@ export default function BenefitsDisplayClient({
     }
   };
 
-  const handleNotUsableChange = (statusId: string, newIsNotUsable: boolean) => {
-    if (newIsNotUsable) {
-      // Moving from upcoming to not usable
-      const benefitToMove = localUpcomingBenefits.find(b => b.id === statusId);
-      if (benefitToMove) {
-        const updatedBenefit = { ...benefitToMove, isNotUsable: true, isCompleted: false, completedAt: null };
-        setLocalUpcomingBenefits(prev => prev.filter(b => b.id !== statusId));
-        setLocalNotUsableBenefits(prev => [...prev, updatedBenefit]);
-        
-        // Update totals
-        const benefitValue = benefitToMove.benefit.maxAmount || 0;
-        setLocalTotalUnusedValue(prev => prev - benefitValue);
-        setLocalTotalNotUsableValue(prev => prev + benefitValue);
-      }
-    } else {
-      // Moving from not usable back to upcoming
-      const benefitToMove = localNotUsableBenefits.find(b => b.id === statusId);
-      if (benefitToMove) {
-        const updatedBenefit = { ...benefitToMove, isNotUsable: false };
-        setLocalNotUsableBenefits(prev => prev.filter(b => b.id !== statusId));
-        setLocalUpcomingBenefits(prev => [...prev, updatedBenefit]);
-        
-        // Update totals
-        const benefitValue = benefitToMove.benefit.maxAmount || 0;
-        setLocalTotalNotUsableValue(prev => prev - benefitValue);
-        setLocalTotalUnusedValue(prev => prev + benefitValue);
-      }
-    }
-  };
-
   const handleDeleteBenefit = (benefitId: string) => {
     // Remove from all lists based on benefit ID
     const findAndRemove = (list: DisplayBenefitStatus[]) => 
@@ -389,7 +359,6 @@ export default function BenefitsDisplayClient({
             key={status.id} 
             status={status} 
             onStatusChange={handleStatusChange} 
-            onNotUsableChange={handleNotUsableChange}
             onDelete={handleDeleteBenefit}
             onPartialCompletionChange={handlePartialCompletionChange}
             isScheduled={true}
@@ -442,7 +411,6 @@ export default function BenefitsDisplayClient({
             category={category}
             benefits={categoryBenefits}
             onStatusChange={handleStatusChange}
-            onNotUsableChange={handleNotUsableChange}
             onDelete={handleDeleteBenefit}
             onPartialCompletionChange={handlePartialCompletionChange}
           />
@@ -494,7 +462,6 @@ export default function BenefitsDisplayClient({
             category={group.label}
             benefits={group.benefits}
             onStatusChange={handleStatusChange}
-            onNotUsableChange={handleNotUsableChange}
             onDelete={handleDeleteBenefit}
             onPartialCompletionChange={handlePartialCompletionChange}
           />

--- a/src/components/BenefitsDisplayClient.tsx
+++ b/src/components/BenefitsDisplayClient.tsx
@@ -20,6 +20,7 @@ import type { BenefitTrackingMode } from '@/lib/benefit-tracking-modes';
 interface BenefitsDisplayProps {
   upcomingBenefits: DisplayBenefitStatus[];
   completedBenefits: DisplayBenefitStatus[];
+  ignoredBenefits?: DisplayBenefitStatus[];
   scheduledBenefits: DisplayBenefitStatus[];
   totalUnusedValue: number;
   totalUsedValue: number;
@@ -33,6 +34,7 @@ interface BenefitsDisplayProps {
 export default function BenefitsDisplayClient({
   upcomingBenefits,
   completedBenefits,
+  ignoredBenefits = [],
   scheduledBenefits,
   totalUnusedValue,
   totalUsedValue,
@@ -56,6 +58,7 @@ export default function BenefitsDisplayClient({
   const [sortMode, setSortMode] = useState<'expires' | 'value' | 'card'>('expires');
   const [localUpcomingBenefits, setLocalUpcomingBenefits] = useState(upcomingBenefits);
   const [localCompletedBenefits, setLocalCompletedBenefits] = useState(completedBenefits);
+  const [localIgnoredBenefits, setLocalIgnoredBenefits] = useState(ignoredBenefits);
   const [localScheduledBenefits, setLocalScheduledBenefits] = useState(scheduledBenefits);
   const [localTotalUnusedValue, setLocalTotalUnusedValue] = useState(totalUnusedValue);
   const [localTotalUsedValue, setLocalTotalUsedValue] = useState(totalUsedValue);
@@ -167,7 +170,7 @@ export default function BenefitsDisplayClient({
       list.filter(b => b.benefit.id !== benefitId);
     
     // Find the benefit to get its value for updating totals
-    const allBenefits = [...localUpcomingBenefits, ...localCompletedBenefits];
+    const allBenefits = [...localUpcomingBenefits, ...localCompletedBenefits, ...localIgnoredBenefits];
     const deletedBenefit = allBenefits.find(b => b.benefit.id === benefitId);
     
     if (deletedBenefit) {
@@ -190,7 +193,8 @@ export default function BenefitsDisplayClient({
   /**
    * Mirror the server-side tracking transition immediately in the dashboard.
    * AUTO_CLAIM claims the currently open row and moves it to Claimed; IGNORE
-   * removes the row from every visible tab and its corresponding totals.
+   * moves the row into the Ignored tab. Restoring an ignored row puts it back
+   * into the tab dictated by its current cycle state.
    */
   const handleTrackingModeChange = (
     statusId: string,
@@ -199,8 +203,9 @@ export default function BenefitsDisplayClient({
   ) => {
     const upcoming = localUpcomingBenefits.find((benefit) => benefit.id === statusId);
     const completed = localCompletedBenefits.find((benefit) => benefit.id === statusId);
+    const ignored = localIgnoredBenefits.find((benefit) => benefit.id === statusId);
     const scheduled = localScheduledBenefits.find((benefit) => benefit.id === statusId);
-    const status = upcoming ?? completed ?? scheduled;
+    const status = upcoming ?? completed ?? ignored ?? scheduled;
     if (!status) return;
 
     const maxAmount = Math.max(0, status.benefit.maxAmount ?? 0);
@@ -211,12 +216,36 @@ export default function BenefitsDisplayClient({
       setLocalUpcomingBenefits((items) => items.filter((item) => item.id !== statusId));
       setLocalCompletedBenefits((items) => items.filter((item) => item.id !== statusId));
       setLocalScheduledBenefits((items) => items.filter((item) => item.id !== statusId));
+      setLocalIgnoredBenefits((items) => [...items.filter((item) => item.id !== statusId), { ...status, trackingMode: mode }]);
 
       if (upcoming) {
         setLocalTotalUnusedValue((value) => value - Math.max(0, maxAmount - usedAmount));
         setLocalTotalUsedValue((value) => value - usedAmount);
       } else if (completed) {
         setLocalTotalUsedValue((value) => value - claimedAmount);
+      }
+      return;
+    }
+
+    if (ignored) {
+      const restoredStatus = { ...ignored, trackingMode: mode };
+      setLocalIgnoredBenefits((items) => items.filter((item) => item.id !== statusId));
+      let restoredToTrackedTab = false;
+      if (restoredStatus.isCompleted) {
+        setLocalCompletedBenefits((items) => [...items, restoredStatus]);
+        restoredToTrackedTab = true;
+      } else if (new Date(restoredStatus.cycleStartDate).getTime() > Date.now()) {
+        setLocalScheduledBenefits((items) => [...items, restoredStatus]);
+        // Scheduled benefits do not contribute to current totals yet.
+      } else if (new Date(restoredStatus.cycleEndDate).getTime() >= Date.now()) {
+        setLocalUpcomingBenefits((items) => [...items, restoredStatus]);
+        restoredToTrackedTab = true;
+      }
+      if (restoredStatus.isCompleted) {
+        setLocalTotalUsedValue((value) => value + claimedAmount);
+      } else if (restoredToTrackedTab) {
+        setLocalTotalUnusedValue((value) => value + Math.max(0, maxAmount - usedAmount));
+        setLocalTotalUsedValue((value) => value + usedAmount);
       }
       return;
     }
@@ -296,10 +325,12 @@ export default function BenefitsDisplayClient({
         return localCompletedBenefits;
       case 'scheduled':
         return localScheduledBenefits;
+      case 'ignored':
+        return localIgnoredBenefits;
       default:
         return [];
     }
-  }, [activeTab, localUpcomingBenefits, localCompletedBenefits, localScheduledBenefits]);
+  }, [activeTab, localUpcomingBenefits, localCompletedBenefits, localScheduledBenefits, localIgnoredBenefits]);
 
   const uniqueCategories = useMemo(
     () => Array.from(new Set(allBenefitsForTab.map((b) => b.benefit.category))).sort(),
@@ -441,6 +472,11 @@ export default function BenefitsDisplayClient({
           title: 'No completed benefits yet',
           description: 'Mark benefits as complete when you use them to track your ROI.',
         },
+        ignored: {
+          icon: 'clock' as const,
+          title: 'No ignored benefits',
+          description: 'Benefits you choose to ignore will appear here for review and restoration.',
+        },
       };
       const props = emptyStateProps[activeTab as keyof typeof emptyStateProps] || emptyStateProps.upcoming;
       return <EmptyState {...props} />;
@@ -459,6 +495,7 @@ export default function BenefitsDisplayClient({
             onDelete={handleDeleteBenefit}
             onPartialCompletionChange={handlePartialCompletionChange}
             onTrackingModeChange={handleTrackingModeChange}
+            isIgnoredView={activeTab === 'ignored'}
           />
         ))}
       </div>
@@ -488,6 +525,11 @@ export default function BenefitsDisplayClient({
           title: 'No Benefits Available',
           description: 'No completed benefits yet. Start using your credit card benefits!',
         },
+        ignored: {
+          icon: 'clock' as const,
+          title: 'No ignored benefits',
+          description: 'Benefits you choose to ignore will appear here for review and restoration.',
+        },
       };
       const props = emptyStateProps[activeTab as keyof typeof emptyStateProps] || emptyStateProps.upcoming;
       return <EmptyState {...props} />;
@@ -506,6 +548,7 @@ export default function BenefitsDisplayClient({
             onDelete={handleDeleteBenefit}
             onPartialCompletionChange={handlePartialCompletionChange}
             onTrackingModeChange={handleTrackingModeChange}
+            isIgnoredView={activeTab === 'ignored'}
           />
         ))}
       </div>
@@ -694,6 +737,16 @@ export default function BenefitsDisplayClient({
               <span className="sm:hidden">Scheduled ({localScheduledBenefits.length})</span>
             </button>
           )}
+          <button
+            onClick={() => setActiveTab('ignored')}
+            className={`flex-shrink-0 py-4 px-1 border-b-2 font-medium text-sm
+              ${activeTab === 'ignored'
+                ? 'border-foreground text-foreground'
+                : 'border-transparent text-muted-foreground hover:border-border hover:text-foreground'}
+            `}
+          >
+            <span>Ignored ({localIgnoredBenefits.length})</span>
+          </button>
         </nav>
       </div>
 
@@ -841,6 +894,18 @@ export default function BenefitsDisplayClient({
               </p>
             </div>
             {renderScheduledBenefitsList(sortBenefits(applyPowerUserFilters(filterBenefits(localScheduledBenefits))))}
+          </section>
+        )}
+        {activeTab === 'ignored' && (
+          <section>
+            <div className="mb-4 rounded-xl border border-border bg-card p-4 shadow-sm shadow-black/[0.03]">
+              <p className="text-sm text-muted-foreground">
+                These benefits are excluded from tracking and totals. Choose a different tracking mode on a benefit to restore it.
+              </p>
+            </div>
+            {viewMode === 'category'
+              ? renderCategoryView(sortBenefits(applyPowerUserFilters(filterBenefits(localIgnoredBenefits))))
+              : renderCardView(sortBenefits(applyPowerUserFilters(filterBenefits(localIgnoredBenefits))))}
           </section>
         )}
       </div>

--- a/src/components/CategoryBenefitsGroup.tsx
+++ b/src/components/CategoryBenefitsGroup.tsx
@@ -4,6 +4,7 @@ import React, { useState, useTransition } from 'react';
 import BenefitCardClient from '@/components/BenefitCardClient';
 import { batchCompleteBenefitsByCategoryAction } from '@/app/benefits/actions';
 import type { DisplayBenefitStatus } from '@/lib/benefit-dashboard-client';
+import type { BenefitTrackingMode } from '@/lib/benefit-tracking-modes';
 import { formatDate } from '@/lib/dateUtils';
 import { calculateBenefitGroupSummary } from '@/lib/benefit-dashboard-client';
 
@@ -13,6 +14,7 @@ interface CategoryBenefitsGroupProps {
   onStatusChange?: (statusId: string, newIsCompleted: boolean, newUsedAmount?: number) => void;
   onDelete?: (benefitId: string) => void;
   onPartialCompletionChange?: (statusId: string, newUsedAmount: number, isNowComplete: boolean) => void;
+  onTrackingModeChange?: (statusId: string, previousMode: BenefitTrackingMode, mode: BenefitTrackingMode) => void;
 }
 
 // Category icons mapping
@@ -153,13 +155,16 @@ export default function CategoryBenefitsGroup({
   benefits, 
   onStatusChange, 
   onDelete,
-  onPartialCompletionChange
+  onPartialCompletionChange,
+  onTrackingModeChange,
 }: CategoryBenefitsGroupProps) {
   const [isExpanded, setIsExpanded] = useState(true);
   const [isPending, startTransition] = useTransition();
 
   // Filter benefits that can be batch completed (not completed and not marked as not usable)
-  const completableBenefits = benefits.filter(benefit => !benefit.isCompleted && !benefit.isNotUsable);
+  const completableBenefits = benefits.filter(
+    (benefit) => !benefit.isCompleted && !benefit.isNotUsable && benefit.trackingMode !== 'AUTO_CLAIM'
+  );
   const categoryTotal = benefits.reduce((sum, benefit) => sum + (benefit.benefit.maxAmount || 0), 0);
   const completedTotal = benefits
     .filter(benefit => benefit.isCompleted)
@@ -256,6 +261,7 @@ export default function CategoryBenefitsGroup({
                 onStatusChange={onStatusChange}
                 onDelete={onDelete}
                 onPartialCompletionChange={onPartialCompletionChange}
+                onTrackingModeChange={onTrackingModeChange}
               />
             ))}
           </div>

--- a/src/components/CategoryBenefitsGroup.tsx
+++ b/src/components/CategoryBenefitsGroup.tsx
@@ -15,6 +15,7 @@ interface CategoryBenefitsGroupProps {
   onDelete?: (benefitId: string) => void;
   onPartialCompletionChange?: (statusId: string, newUsedAmount: number, isNowComplete: boolean) => void;
   onTrackingModeChange?: (statusId: string, previousMode: BenefitTrackingMode, mode: BenefitTrackingMode) => void;
+  isIgnoredView?: boolean;
 }
 
 // Category icons mapping
@@ -157,12 +158,13 @@ export default function CategoryBenefitsGroup({
   onDelete,
   onPartialCompletionChange,
   onTrackingModeChange,
+  isIgnoredView = false,
 }: CategoryBenefitsGroupProps) {
   const [isExpanded, setIsExpanded] = useState(true);
   const [isPending, startTransition] = useTransition();
 
   // Filter benefits that can be batch completed (all open benefits)
-  const completableBenefits = benefits.filter(
+  const completableBenefits = isIgnoredView ? [] : benefits.filter(
     (benefit) => !benefit.isCompleted && benefit.trackingMode !== 'AUTO_CLAIM'
   );
   const categoryTotal = benefits.reduce((sum, benefit) => sum + (benefit.benefit.maxAmount || 0), 0);
@@ -262,6 +264,7 @@ export default function CategoryBenefitsGroup({
                 onDelete={onDelete}
                 onPartialCompletionChange={onPartialCompletionChange}
                 onTrackingModeChange={onTrackingModeChange}
+                isIgnoredView={isIgnoredView}
               />
             ))}
           </div>

--- a/src/components/CategoryBenefitsGroup.tsx
+++ b/src/components/CategoryBenefitsGroup.tsx
@@ -161,9 +161,9 @@ export default function CategoryBenefitsGroup({
   const [isExpanded, setIsExpanded] = useState(true);
   const [isPending, startTransition] = useTransition();
 
-  // Filter benefits that can be batch completed (not completed and not marked as not usable)
+  // Filter benefits that can be batch completed (all open benefits)
   const completableBenefits = benefits.filter(
-    (benefit) => !benefit.isCompleted && !benefit.isNotUsable && benefit.trackingMode !== 'AUTO_CLAIM'
+    (benefit) => !benefit.isCompleted && benefit.trackingMode !== 'AUTO_CLAIM'
   );
   const categoryTotal = benefits.reduce((sum, benefit) => sum + (benefit.benefit.maxAmount || 0), 0);
   const completedTotal = benefits

--- a/src/components/CategoryBenefitsGroup.tsx
+++ b/src/components/CategoryBenefitsGroup.tsx
@@ -11,7 +11,6 @@ interface CategoryBenefitsGroupProps {
   category: string;
   benefits: DisplayBenefitStatus[];
   onStatusChange?: (statusId: string, newIsCompleted: boolean, newUsedAmount?: number) => void;
-  onNotUsableChange?: (statusId: string, newIsNotUsable: boolean) => void;
   onDelete?: (benefitId: string) => void;
   onPartialCompletionChange?: (statusId: string, newUsedAmount: number, isNowComplete: boolean) => void;
 }
@@ -153,7 +152,6 @@ export default function CategoryBenefitsGroup({
   category, 
   benefits, 
   onStatusChange, 
-  onNotUsableChange,
   onDelete,
   onPartialCompletionChange
 }: CategoryBenefitsGroupProps) {
@@ -256,7 +254,6 @@ export default function CategoryBenefitsGroup({
                 key={benefit.id} 
                 status={benefit} 
                 onStatusChange={onStatusChange}
-                onNotUsableChange={onNotUsableChange}
                 onDelete={onDelete}
                 onPartialCompletionChange={onPartialCompletionChange}
               />

--- a/src/components/__tests__/BenefitCardClient.test.tsx
+++ b/src/components/__tests__/BenefitCardClient.test.tsx
@@ -139,12 +139,13 @@ describe('BenefitCardClient', () => {
   });
 
   it('keeps ignored cards read-only while allowing tracking restoration', () => {
-    const status = createMockStatus({ trackingMode: 'IGNORE' });
+    const status = createMockStatus({ trackingMode: 'IGNORE', isCustomBenefit: true });
     render(<BenefitCardClient status={status} isIgnoredView />);
 
     expect(screen.getByText('Ignored')).toBeInTheDocument();
     expect(screen.queryByRole('button', { name: /Mark Complete/i })).not.toBeInTheDocument();
     expect(screen.queryByRole('button', { name: /Add Amount/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Delete/i })).not.toBeInTheDocument();
     expect(screen.getByRole('button', { name: /Tracking mode: Ignore this benefit/i })).toBeInTheDocument();
   });
 

--- a/src/components/__tests__/BenefitCardClient.test.tsx
+++ b/src/components/__tests__/BenefitCardClient.test.tsx
@@ -138,6 +138,16 @@ describe('BenefitCardClient', () => {
     expect(screen.getByRole('button', { name: /Track every cycle/i })).toHaveAttribute('aria-pressed', 'false');
   });
 
+  it('keeps ignored cards read-only while allowing tracking restoration', () => {
+    const status = createMockStatus({ trackingMode: 'IGNORE' });
+    render(<BenefitCardClient status={status} isIgnoredView />);
+
+    expect(screen.getByText('Ignored')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Mark Complete/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Add Amount/i })).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Tracking mode: Ignore this benefit/i })).toBeInTheDocument();
+  });
+
   it('updates the visible mode after a successful tracking choice', async () => {
     const status = createMockStatus();
     render(<BenefitCardClient status={status} />);

--- a/src/components/__tests__/BenefitCardClient.test.tsx
+++ b/src/components/__tests__/BenefitCardClient.test.tsx
@@ -157,11 +157,11 @@ describe('BenefitCardClient', () => {
     expect(screen.queryByRole('button', { name: /Not usable this cycle|Mark usable this cycle/i })).not.toBeInTheDocument();
   });
 
-  it('keeps legacy not-usable statuses visible without mutation controls', () => {
+  it('does not present a legacy not-usable status differently', () => {
     const status = createMockStatus({ isNotUsable: true });
     render(<BenefitCardClient status={status} />);
 
-    expect(screen.getByText('Not usable')).toBeInTheDocument();
-    expect(screen.queryByRole('button', { name: /Not usable this cycle|Mark usable this cycle/i })).not.toBeInTheDocument();
+    expect(screen.getByText('Open')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Mark Complete/i })).toBeInTheDocument();
   });
 });

--- a/src/components/__tests__/BenefitCardClient.test.tsx
+++ b/src/components/__tests__/BenefitCardClient.test.tsx
@@ -3,7 +3,7 @@
  */
 
 import React from 'react';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import BenefitCardClient from '../BenefitCardClient';
 import type { DisplayBenefitStatus } from '@/lib/benefit-dashboard-client';
 
@@ -13,6 +13,7 @@ jest.mock('@/app/benefits/actions', () => ({
   deleteCustomBenefitAction: jest.fn().mockResolvedValue(undefined),
   addPartialCompletionAction: jest.fn().mockResolvedValue({ success: true, isComplete: false, newUsedAmount: 10 }),
   markFullCompletionAction: jest.fn().mockResolvedValue({ success: true, usedAmount: 10 }),
+  setBenefitTrackingModeAction: jest.fn().mockResolvedValue(undefined),
 }));
 
 jest.mock('@/lib/partial-completion', () => ({
@@ -121,6 +122,42 @@ describe('BenefitCardClient', () => {
     expect(screen.getByRole('link', { name: /How to use/i })).toHaveAttribute(
       'href',
       '/benefits/how-to-use/brilliant-doordash-amazon-gift-card'
+    );
+  });
+
+  it('shows the current tracking mode in the trigger and marks it selected', () => {
+    const status = createMockStatus({ trackingMode: 'IGNORE' });
+    render(<BenefitCardClient status={status} />);
+
+    const trigger = screen.getByRole('button', { name: /Tracking mode: Ignore this benefit/i });
+    expect(trigger).toHaveAttribute('aria-expanded', 'false');
+
+    fireEvent.click(trigger);
+
+    const selectedOption = screen.getByRole('button', { name: /Ignore this benefit.*Current/i });
+    expect(selectedOption).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.getByRole('button', { name: /Track every cycle/i })).toHaveAttribute('aria-pressed', 'false');
+  });
+
+  it('updates the visible mode after a successful tracking choice', async () => {
+    const status = createMockStatus();
+    render(<BenefitCardClient status={status} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /Tracking mode: Track every cycle/i }));
+    fireEvent.click(screen.getByRole('button', { name: /Always claim it for me/i }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /Tracking mode: Always claim it for me/i })).toBeInTheDocument();
+    });
+  });
+
+  it('labels the cycle-level unusable action distinctly from Ignore', () => {
+    const status = createMockStatus();
+    render(<BenefitCardClient status={status} />);
+
+    expect(screen.getByRole('button', { name: /Not usable this cycle/i })).toHaveAttribute(
+      'title',
+      expect.stringContaining('ignore this benefit in every cycle')
     );
   });
 });

--- a/src/components/__tests__/BenefitCardClient.test.tsx
+++ b/src/components/__tests__/BenefitCardClient.test.tsx
@@ -9,7 +9,6 @@ import type { DisplayBenefitStatus } from '@/lib/benefit-dashboard-client';
 
 jest.mock('@/app/benefits/actions', () => ({
   toggleBenefitStatusAction: jest.fn().mockResolvedValue(undefined),
-  markBenefitAsNotUsableAction: jest.fn().mockResolvedValue(undefined),
   deleteCustomBenefitAction: jest.fn().mockResolvedValue(undefined),
   addPartialCompletionAction: jest.fn().mockResolvedValue({ success: true, isComplete: false, newUsedAmount: 10 }),
   markFullCompletionAction: jest.fn().mockResolvedValue({ success: true, usedAmount: 10 }),
@@ -151,13 +150,18 @@ describe('BenefitCardClient', () => {
     });
   });
 
-  it('labels the cycle-level unusable action distinctly from Ignore', () => {
+  it('does not expose the deprecated cycle-level not-usable action', () => {
     const status = createMockStatus();
     render(<BenefitCardClient status={status} />);
 
-    expect(screen.getByRole('button', { name: /Not usable this cycle/i })).toHaveAttribute(
-      'title',
-      expect.stringContaining('ignore this benefit in every cycle')
-    );
+    expect(screen.queryByRole('button', { name: /Not usable this cycle|Mark usable this cycle/i })).not.toBeInTheDocument();
+  });
+
+  it('keeps legacy not-usable statuses visible without mutation controls', () => {
+    const status = createMockStatus({ isNotUsable: true });
+    render(<BenefitCardClient status={status} />);
+
+    expect(screen.getByText('Not usable')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Not usable this cycle|Mark usable this cycle/i })).not.toBeInTheDocument();
   });
 });

--- a/src/components/__tests__/BenefitsDisplayClient.test.tsx
+++ b/src/components/__tests__/BenefitsDisplayClient.test.tsx
@@ -42,11 +42,9 @@ jest.mock('../CategoryBenefitsGroup', () => ({
 const defaultProps = {
   upcomingBenefits: [] as DisplayBenefitStatus[],
   completedBenefits: [] as DisplayBenefitStatus[],
-  notUsableBenefits: [] as DisplayBenefitStatus[],
   scheduledBenefits: [] as DisplayBenefitStatus[],
   totalUnusedValue: 0,
   totalUsedValue: 0,
-  totalNotUsableValue: 0,
   totalAnnualFees: 0,
 };
 
@@ -122,12 +120,12 @@ function benefitStatus(
 }
 
 describe('BenefitsDisplayClient', () => {
-  it('renders tabs for Upcoming, Claimed, and Not usable', () => {
+  it('renders tabs for Upcoming and Claimed without the deprecated Not Usable tab', () => {
     render(<BenefitsDisplayClient {...defaultProps} />);
 
     expect(screen.getByRole('button', { name: /Upcoming/i })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /Claimed/i })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /Not Usable/i })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Not Usable/i })).not.toBeInTheDocument();
   });
 
   it('renders summary widgets with value totals', () => {
@@ -142,6 +140,7 @@ describe('BenefitsDisplayClient', () => {
 
     expect(screen.getByText('Claimed Benefits')).toBeInTheDocument();
     expect(screen.getByText('Annual Fee ROI')).toBeInTheDocument();
+    expect(screen.queryByText('Not Usable')).not.toBeInTheDocument();
     expect(screen.getByText(/\$50\.00 claimed vs \$95\.00 fees/)).toBeInTheDocument();
   });
 

--- a/src/components/__tests__/BenefitsDisplayClient.test.tsx
+++ b/src/components/__tests__/BenefitsDisplayClient.test.tsx
@@ -126,6 +126,19 @@ describe('BenefitsDisplayClient', () => {
     expect(screen.getByRole('button', { name: /Upcoming/i })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /Claimed/i })).toBeInTheDocument();
     expect(screen.queryByRole('button', { name: /Not Usable/i })).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Ignored \(0\)/i })).toBeInTheDocument();
+  });
+
+  it('shows ignored benefits in the Ignored tab', () => {
+    render(
+      <BenefitsDisplayClient
+        {...defaultProps}
+        ignoredBenefits={[{ ...benefitStatus('ignored', 'Ignored dining credit', 'MONTHLY'), trackingMode: 'IGNORE' }]}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /Ignored \(1\)/i }));
+    expect(screen.getByText('Ignored dining credit')).toBeInTheDocument();
   });
 
   it('renders summary widgets with value totals', () => {

--- a/src/components/__tests__/BenefitsDisplayClient.test.tsx
+++ b/src/components/__tests__/BenefitsDisplayClient.test.tsx
@@ -14,13 +14,25 @@ jest.mock('../BenefitCardClient', () => {
 });
 jest.mock('../CategoryBenefitsGroup', () => ({
   __esModule: true,
-  default: function MockCategoryBenefitsGroup({ category, benefits }: { category: string; benefits: DisplayBenefitStatus[] }) {
+  default: function MockCategoryBenefitsGroup({
+    category,
+    benefits,
+    onTrackingModeChange,
+  }: {
+    category: string;
+    benefits: DisplayBenefitStatus[];
+    onTrackingModeChange?: (statusId: string, previousMode: 'TRACK' | 'AUTO_CLAIM' | 'IGNORE', mode: 'TRACK' | 'AUTO_CLAIM' | 'IGNORE') => void;
+  }) {
     return (
       <div data-testid="category-group">
         <h2>{category}</h2>
         <div data-testid="category-count">{benefits.length}</div>
         {benefits.map((b) => (
-          <div key={b.id}>{b.benefit.description}</div>
+          <div key={b.id}>
+            {b.benefit.description}
+            <button type="button" onClick={() => onTrackingModeChange?.(b.id, 'TRACK', 'AUTO_CLAIM')}>Auto claim</button>
+            <button type="button" onClick={() => onTrackingModeChange?.(b.id, 'TRACK', 'IGNORE')}>Ignore</button>
+          </div>
         ))}
       </div>
     );
@@ -249,5 +261,39 @@ describe('BenefitsDisplayClient', () => {
     expect(screen.getAllByText('American Express Gold Card')).toHaveLength(2);
     expect(groups[0]).toHaveTextContent('Dining credit - first physical card');
     expect(groups[1]).toHaveTextContent('Dining credit - second physical card');
+  });
+
+  it('moves an open benefit to Claimed when AUTO_CLAIM is selected', () => {
+    render(
+      <BenefitsDisplayClient
+        {...defaultProps}
+        upcomingBenefits={[benefitStatus('auto', 'Auto claim me', 'MONTHLY')]}
+        totalUnusedValue={100}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Auto claim' }));
+
+    expect(screen.getByRole('button', { name: /Claimed \(1\)/i })).toBeInTheDocument();
+    expect(screen.getByText('Claimed Benefits')).toBeInTheDocument();
+    expect(screen.getAllByText('$100.00').length).toBeGreaterThan(0);
+    expect(screen.getByRole('button', { name: /Upcoming \(0\)/i })).toBeInTheDocument();
+  });
+
+  it('removes an ignored benefit from the dashboard and totals', () => {
+    render(
+      <BenefitsDisplayClient
+        {...defaultProps}
+        upcomingBenefits={[benefitStatus('ignore', 'Ignore me', 'MONTHLY')]}
+        totalUnusedValue={100}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Ignore' }));
+
+    expect(screen.queryByText('Ignore me')).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Upcoming \(0\)/i })).toBeInTheDocument();
+    expect(screen.getByText('Upcoming Benefits')).toBeInTheDocument();
+    expect(screen.getAllByText('$0.00').length).toBeGreaterThan(0);
   });
 });

--- a/src/lib/__tests__/benefit-dashboard.test.ts
+++ b/src/lib/__tests__/benefit-dashboard.test.ts
@@ -226,6 +226,7 @@ describe('buildBenefitDashboardProjection', () => {
 
     expect(tracked.completedBenefits.map((item) => item.id)).toEqual(['ignored']);
     expect(withIgnored.completedBenefits).toEqual([]);
+    expect(withIgnored.ignoredBenefits.map((item) => item.id)).toEqual(['ignored']);
     expect(withIgnored.upcomingBenefits.map((item) => item.id)).toEqual(['kept']);
     // The ignored benefit stops contributing its claimed value to ROI.
     expect(withIgnored.totalUsedValue).toBe(tracked.totalUsedValue - 50);

--- a/src/lib/benefit-dashboard.ts
+++ b/src/lib/benefit-dashboard.ts
@@ -61,6 +61,8 @@ export interface PredefinedCardFee {
 export interface BenefitDashboardProjection {
   upcomingBenefits: DisplayBenefitStatus[];
   completedBenefits: DisplayBenefitStatus[];
+  /** Benefits explicitly excluded from tracking, kept visible for review/restoration. */
+  ignoredBenefits: DisplayBenefitStatus[];
   notUsableBenefits: DisplayBenefitStatus[];
   scheduledBenefits: DisplayBenefitStatus[];
   totalUnusedValue: number;
@@ -292,12 +294,14 @@ export function buildBenefitDashboardProjection({
   now: Date;
   trackingModes?: BenefitTrackingModeMap;
 }): BenefitDashboardProjection {
-  // Ignored benefits are dropped before partitioning so they stay out of the
-  // dashboard, claimed-value totals, and card-level ROI alike.
-  const trackedStatuses = excludeIgnoredBenefits(statuses, trackingModes);
-  const augmentedStatuses = augmentBenefitStatusesForDashboard(trackedStatuses, userCards, usageWays, trackingModes);
+  // Keep ignored benefits in a dedicated read-only partition. They remain out
+  // of tracked tabs, totals, and card-level ROI, while still being available
+  // for users to review and restore.
+  const augmentedStatuses = augmentBenefitStatusesForDashboard(statuses, userCards, usageWays, trackingModes);
   const deduplicatedStatuses = deduplicateBenefitStatusesForDashboard(augmentedStatuses);
-  const partitions = partitionBenefitStatusesForDashboard(deduplicatedStatuses, now);
+  const ignoredBenefits = deduplicatedStatuses.filter((status) => status.trackingMode === 'IGNORE');
+  const trackedStatuses = excludeIgnoredBenefits(deduplicatedStatuses, trackingModes);
+  const partitions = partitionBenefitStatusesForDashboard(trackedStatuses, now);
   const totals = calculateBenefitDashboardTotals(partitions);
   const roi = calculateCardLevelRoi(
     [...partitions.upcomingBenefits, ...partitions.completedBenefits],
@@ -307,6 +311,7 @@ export function buildBenefitDashboardProjection({
 
   return {
     ...partitions,
+    ignoredBenefits,
     ...totals,
     ...roi,
   };

--- a/src/lib/benefit-tracking-modes.ts
+++ b/src/lib/benefit-tracking-modes.ts
@@ -9,8 +9,8 @@
  *   no preference row exists.
  * - `AUTO_CLAIM` materializes each new cycle already claimed, so the benefit
  *   leaves the to-do list but still counts toward claimed value and ROI.
- * - `IGNORE` removes the benefit from the dashboard entirely and excludes it
- *   from claimed value and ROI.
+ * - `IGNORE` moves the benefit to the dashboard's Ignored tab and excludes it
+ *   from tracked tabs, claimed value, and ROI.
  *
  * Every function here is pure so the behaviour can be tested without a
  * database.
@@ -92,8 +92,8 @@ export function resolveBenefitTrackingMode(
 }
 
 /**
- * Drops the benefits the user chose to ignore. Applied before any dashboard
- * partitioning so totals and ROI exclude them too.
+ * Drops the benefits the user chose to ignore from tracked projections. The
+ * dashboard keeps a separate Ignored tab for review and restoration.
  */
 export function excludeIgnoredBenefits<T extends BenefitTrackingTarget>(
   rows: readonly T[],


### PR DESCRIPTION
## Summary
- Deprecate the legacy Not Usable dashboard flow and migrate legacy `isNotUsable` rows to the cycle-independent `IGNORE` preference.
- Add an Ignored dashboard tab with read-only cards and an explicit restore path.
- Make tracking mode visible and highlighted per benefit; keep completion controls unavailable for ignored and auto-claim rows.
- Preserve AMEX/audit compatibility for the legacy column while clearing it during migration and mode changes.

## Validation
- `npm test -- --runInBand` (88 suites, 845 tests)
- `npx tsc --noEmit --pretty false --incremental false`
- ESLint on changed files
- `npm run check:public-db`
- `git diff --check`

@zhaoliu1996 — this builds on your original tracking-mode work. Please review the migration and the Ignored-tab behavior, especially restoration semantics.